### PR TITLE
Cleanup Anchors and add String Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Specific goals for the BRex language include:
 
 - **Tooling**: As part of the BRex project we aim to provide a rich tooling ecosystem for working with these expressions. This includes tools for testing, sampling inputs, and synthesizing expressions from examples, and IDE highlighting/linting.
 
-- **Universality** BRex is designed for everyone! Unicode (utf8) support is part of the design and implementation from the start and ASCII regexes are a distinct subset for use where the simplicity of the ASCII subset is desired.
+- **Universality** BRex is designed for everyone! Unicode (utf8) support is part of the design and implementation from the start and simple Char regexes are a distinct subset for use where the simplicity of the printable + whitespace ASCII subset is desired.
 
 ## Overall Design
 BRex introduces new (text)[docs/regex_semantics.md] and (path)[docs/path_semantics.md] languages + core infrastructure components for structured text processing. The goal is to provide a core [native API](docs/native_api.md) for embedding into other applications that operates on byte buffers and provides a uniform interface for operating on strings with regular expressions. On top of this core API this project exposes a Node.js native module **TODO** and a (command line tool)[docs/brex_cmd.md], `brex`, that provides a simple AWK like interface for using BRex expressions to process text files. Finally, the project plans to leverage improvements in the expression semantics to create improved (and novel new) tools to working with these languages (see the issues tracker).
 
-Unicode support is a foundational part of the BRex design and implementation. As such the BRex language support the full unicode char set and is fully utf8 aware. However, in many cases the simplicity of ASCII regexes is desired and BRex provides an explicit ASCII regex and processing pipeline as well. 
+Unicode support is a foundational part of the BRex design and implementation. As such the BRex language support the full unicode char set and is fully utf8 aware. However, in many cases the simplicity is desired and BRex provides an explicit simple ASCII Char regex and processing pipeline as well. 
 
 The matching engine is based on a NFA simulation to ensure that the average case performance is efficient and that the worst case performance is not pathalogical ([ReDOS](https://en.wikipedia.org/wiki/ReDoS)). We also restrict the regex forms used in searching so that we can always use a fast string search algorithm (e.g. [Boyer-Moore](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm)) to quickly scan for start/end positions. This ensures that BRex can be used in a wide range of applications, particularly data validation, without severe risks around performance issues.
 
@@ -59,9 +59,9 @@ In BRex this is expressed as and defaults to a Unicode regex:
 /"h"[aeiou]+/
 ```
 
-We can also specify that it matches ASCII (using an ascii literal and the `a` flag):
+We can also specify that it matches ASCII printable and whitespace (using an c literal and the `c` flag):
 ```
-/'h'[aeiou]+/a
+/'h'[aeiou]+/c
 ```
 
 Comments and line breaks are fine too (note whitespace is ignored outside of literals and ranges):

--- a/README.md
+++ b/README.md
@@ -146,19 +146,12 @@ For a file like mark_abc.txt we can match the abc part but make sure it is conta
 The BRex API provides a range of matching/testing algorithms for various text processing scenarios. All matching algorithms are specialized (via templates) for both Unicode and ASCII processing.
 
 ### Testing for a match
-The simplist case is to take a string (or slice/view) and test if it is in the language described by the BRex expression. This is the `test` method.
+The simplist case is to take a string and test if it is in the language described by the BRex expression. This is the `test` method.
 ```C
 bool test(TStr* sstr, ExecutorError& error);
 ```
 
-More interesting is allowing anchors that extend beyond the bounds of the view. Useful for lookahead or behind parsing scenarios.
-```C
-bool test(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error);
-```
-
-In this case the string between `spos` and `epos` is matched and, if desired, the `oobPrefix`/`oobPostfix` flags are set too allow the anchor expressions to extend beyond these bounds.
-
-BRex similarly provides a `testFront` and `testBack` method that allow for testing if a string starts or ends with a match to the BRex expression as well as a `testContains`.
+In this case the string between `spos` and `epos` is matched. BRex similarly provides a `testFront` and `testBack` method that allow for testing if a string starts or ends with a match to the BRex expression as well as a `testContains`.
 
 ### Finding a match
 BRex does not provide grouping or lazy/eager matches. Instead it always finds the longest match **over the full expression** (TODO we also want to allow shortest). This ensures that the matching is unique and predictable. You can then chunk out individual parts of the match in additional.
@@ -170,5 +163,5 @@ std::optional<std::pair<int64_t, int64_t>> matchContains(TStr* sstr, ExecutorErr
 
 Where the `std::pair` result is the start and end position of the FIRST match in the string and the LONGEST possible match.
 
-As with test we also provide `matchFront` and `matchBack` methods that allow for finding the first match at the start or end of the string. And a more verbose version that allows subrange matches and out of bounds anchors.
+As with test we also provide `matchFront` and `matchBack` methods that allow for finding the first match at the start or end of the string. And a more verbose version that allows subrange matches.
         

--- a/build/makefile
+++ b/build/makefile
@@ -41,7 +41,7 @@ PATH_HEADERS=$(PTH_DIR)path.h $(PTH_DIR)path_fragment.h $(PTH_DIR)path_glob.h
 PATH_SOURCES=$(PTH_DIR)path_glob.cpp
 PATH_OBJS=$(OUT_OBJ)path_glob.o
 
-REGEX_TEST_SOURCES=$(REGEX_TEST_SRC_DIR)main.cpp $(REGEX_TEST_SRC_DIR)parsing_ok.cpp $(REGEX_TEST_SRC_DIR)parsing_err.cpp $(REGEX_TEST_SRC_DIR)test.cpp $(REGEX_TEST_SRC_DIR)other_ops.cpp $(REGEX_TEST_SRC_DIR)docs.cpp
+REGEX_TEST_SOURCES=$(REGEX_TEST_SRC_DIR)main.cpp $(REGEX_TEST_SRC_DIR)validate_string.cpp $(REGEX_TEST_SRC_DIR)parsing_ok.cpp $(REGEX_TEST_SRC_DIR)parsing_err.cpp $(REGEX_TEST_SRC_DIR)test.cpp $(REGEX_TEST_SRC_DIR)other_ops.cpp $(REGEX_TEST_SRC_DIR)docs.cpp
 
 MAKEFLAGS += -j4
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -93,40 +93,12 @@ namespace brex
         {126, "%tilde;"}
     };
 
-    std::vector<std::pair<uint8_t, const char*>> s_escape_names_ascii = {
-        {0, "%NUL;"},
-        {1, "%SOH;"},
-        {2, "%STX;"},
-        {3, "%ETX;"},
-        {4, "%EOT;"},
-        {5, "%ENQ;"},
-        {6, "%ACK;"},
-        {7, "%a;"},
-        {8, "%b;"},
+    std::vector<std::pair<uint8_t, const char*>> s_escape_names_char = {
         {9, "%t;"},
         {10, "%n;"},
         {11, "%v;"},
         {12, "%f;"},
         {13, "%r;"},
-        {14, "%SO;"},
-        {15, "%SI;"},
-        {16, "%DLE;"},
-        {17, "%DC1;"},
-        {18, "%DC2;"},
-        {19, "%DC3;"},
-        {20, "%DC4;"},
-        {21, "%NAK;"},
-        {22, "%SYN;"},
-        {23, "%ETB;"},
-        {24, "%CAN;"},
-        {25, "%EM;"},
-        {26, "%SUB;"},
-        {27, "%e;"},
-        {28, "%FS;"},
-        {29, "%GS;"},
-        {30, "%RS;"},
-        {31, "%US;"},
-        {127, "%DEL;"},
 
         {32, "%space;"},
         {33, "%bang;"},
@@ -232,11 +204,11 @@ namespace brex
         return std::distance(s, e) > 3 && *s == '%' && *(s + 1) == 'x' && std::isxdigit(*(s + 2));
     }
 
-    std::optional<RegexChar> decodeHexEscapeAsRegex(const uint8_t* s, const uint8_t* e, bool isascii, bool strictascii)
+    std::optional<RegexChar> decodeHexEscapeAsRegex(const uint8_t* s, const uint8_t* e, bool ischar)
     {
         size_t ccount = std::distance(s, e);
 
-        if(isascii) {
+        if(ischar) {
             //1-2 digits and a %x...;
             if(ccount < 4 || 5 < ccount) {
                 return std::nullopt;
@@ -260,11 +232,11 @@ namespace brex
 
         uint32_t cval = 0;
         auto sct = sscanf((char*)s, "%%x%x;", &cval);
-        if(sct != 1 || cval > (isascii ? 0x7E : 0x10FFFF)) {
+        if(sct != 1 || cval > (ischar ? 0x7E : 0x10FFFF)) {
             return std::nullopt;
         }
         else {
-            if(strictascii && cval <= 127 && !std::isprint(cval) && !std::isspace(cval)) {
+            if(ischar && cval <= 127 && !std::isprint(cval) && !std::isspace(cval)) {
                 return std::nullopt;
             }
 
@@ -302,7 +274,7 @@ namespace brex
         }
     }
 
-    std::optional<ASCIIString> decodeHexEscapeAsASCII(const uint8_t* s, const uint8_t* e, bool strict)
+    std::optional<CString> decodeHexEscapeAsC(const uint8_t* s, const uint8_t* e)
     {
         size_t ccount = std::distance(s, e);
 
@@ -317,11 +289,11 @@ namespace brex
             return std::nullopt;
         }
         else {
-            if(strict && cval <= 127 && !std::isprint(cval) && !std::isspace(cval)) {
+            if(cval <= 127 && !std::isprint(cval) && !std::isspace(cval)) {
                 return std::nullopt;
             }
 
-            return std::make_optional<ASCIIString>({ (ASCIIStringChar)cval });
+            return std::make_optional<CString>({ (CStringChar)cval });
         }
     }
 
@@ -362,24 +334,24 @@ namespace brex
         }
     }
 
-    const char* resolveEscapeASCIIFromCode(ASCIIStringChar c)
+    const char* resolveEscapeCFromCode(CStringChar c)
     {
-        auto ii = std::find_if(s_escape_names_ascii.cbegin(), s_escape_names_ascii.cend(), [c](const std::pair<uint8_t, const char*>& p) { 
+        auto ii = std::find_if(s_escape_names_char.cbegin(), s_escape_names_char.cend(), [c](const std::pair<uint8_t, const char*>& p) { 
             return p.first == c; 
         });
         return ii->second;
     }
 
-    std::optional<uint8_t> resolveEscapeASCIIFromName(const uint8_t* s, const uint8_t* e, bool strict)
+    std::optional<uint8_t> resolveEscapeCFromName(const uint8_t* s, const uint8_t* e)
     {
-        auto ii = std::find_if(s_escape_names_ascii.cbegin(), s_escape_names_ascii.cend(), [s, e](const std::pair<uint8_t, const char*>& p) { 
+        auto ii = std::find_if(s_escape_names_char.cbegin(), s_escape_names_char.cend(), [s, e](const std::pair<uint8_t, const char*>& p) { 
             return std::equal(p.second, p.second + strlen(p.second), s, e); 
         });
-        if(ii == s_escape_names_ascii.cend()) {
+        if(ii == s_escape_names_char.cend()) {
             return std::nullopt;
         }
         else {
-            if(strict && ii->first <= 127 && !std::isprint(ii->first) && !std::isspace(ii->first)) {
+            if(ii->first <= 127 && !std::isprint(ii->first) && !std::isspace(ii->first)) {
                 return std::nullopt;
             }
 
@@ -451,9 +423,9 @@ namespace brex
         return acc;
     }
 
-    std::optional<ASCIIString> unescapeASCIIString(const uint8_t* bytes, size_t length, bool strict)
+    std::optional<CString> unescapeCString(const uint8_t* bytes, size_t length)
     {
-        std::vector<ASCIIStringChar> acc;
+        std::vector<CStringChar> acc;
         for(size_t i = 0; i < length; ++i) {
             uint8_t c = bytes[i];
 
@@ -468,7 +440,7 @@ namespace brex
                 }
 
                 if(isHexEscapePrefix(bytes + i, sc + 1)) {
-                    auto esc = decodeHexEscapeAsASCII(bytes + i, sc + 1, strict);
+                    auto esc = decodeHexEscapeAsC(bytes + i, sc + 1);
                     if(!esc.has_value()) {
                         return std::nullopt;
                     }
@@ -476,7 +448,7 @@ namespace brex
                     std::copy(esc.value().cbegin(), esc.value().cend(), std::back_inserter(acc));
                 }
                 else {
-                    auto esc = resolveEscapeASCIIFromName(bytes + i, sc + 1, strict);
+                    auto esc = resolveEscapeCFromName(bytes + i, sc + 1);
                     if(!esc.has_value()) {
                         return std::nullopt;
                     }
@@ -491,17 +463,17 @@ namespace brex
             }
         }
 
-        return std::make_optional<ASCIIString>(acc.cbegin(), acc.cend());
+        return std::make_optional<CString>(acc.cbegin(), acc.cend());
     }
 
-    std::vector<uint8_t> escapeASCIIString(const ASCIIString& sv)
+    std::vector<uint8_t> escapeCString(const CString& sv)
     {
         std::vector<uint8_t> acc = {};
         for(auto ii = sv.cbegin(); ii != sv.cend(); ++ii) {
             char c = *ii;
 
             if(c == '%' || c == '\'' || !std::isprint(c)) {
-                auto escc = resolveEscapeASCIIFromCode(c);
+                auto escc = resolveEscapeCFromCode(c);
                 while(*escc != '\0') {
                     acc.push_back(*escc++);
                 }
@@ -532,7 +504,7 @@ namespace brex
 
                 if(isHexEscapePrefix(bytes + i, sc + 1)) {
                     //it should be a hex number
-                    auto esc = decodeHexEscapeAsRegex(bytes + i, sc + 1, false, false);
+                    auto esc = decodeHexEscapeAsRegex(bytes + i, sc + 1, false);
                     if(!esc.has_value()) {
                         return std::nullopt;
                     }
@@ -560,7 +532,7 @@ namespace brex
         return std::make_optional<std::vector<RegexChar>>(acc.cbegin(), acc.cend());
     }
 
-    std::optional<std::vector<RegexChar>> unescapeASCIIRegexLiteral(const uint8_t* bytes, size_t length, bool strict)
+    std::optional<std::vector<RegexChar>> unescapeCRegexLiteral(const uint8_t* bytes, size_t length)
     {
         std::vector<RegexChar> acc;
         for(size_t i = 0; i < length; ++i) {
@@ -577,7 +549,7 @@ namespace brex
                 }
 
                 if(isHexEscapePrefix(bytes + i, sc + 1)) {
-                    auto esc = decodeHexEscapeAsRegex(bytes + i, sc + 1, true, strict);
+                    auto esc = decodeHexEscapeAsRegex(bytes + i, sc + 1, true);
                     if(!esc.has_value()) {
                         return std::nullopt;
                     }
@@ -585,7 +557,7 @@ namespace brex
                     acc.push_back(esc.value());
                 }
                 else {
-                    auto esc = resolveEscapeASCIIFromName(bytes + i, sc + 1, strict);
+                    auto esc = resolveEscapeCFromName(bytes + i, sc + 1);
                     if(!esc.has_value()) {
                         return std::nullopt;
                     }
@@ -606,20 +578,20 @@ namespace brex
     std::optional<RegexChar> unescapeSingleUnicodeRegexChar(const uint8_t* s, const uint8_t* e)
     {
         if(isHexEscapePrefix(s, e)) {
-            return decodeHexEscapeAsRegex(s, e, false, false);
+            return decodeHexEscapeAsRegex(s, e, false);
         }
         else {
             return resolveEscapeUnicodeFromName(s, e);
         }
     }
 
-    std::optional<RegexChar> unescapeSingleASCIIRegexChar(const uint8_t* s, const uint8_t* e, bool strict)
+    std::optional<RegexChar> unescapeSingleCRegexChar(const uint8_t* s, const uint8_t* e)
     {
         if(isHexEscapePrefix(s, e)) {
-            return decodeHexEscapeAsRegex(s, e, true, strict);
+            return decodeHexEscapeAsRegex(s, e, true);
         }
         else {
-            return resolveEscapeASCIIFromName(s, e, strict);
+            return resolveEscapeCFromName(s, e);
         }
     }
 
@@ -663,12 +635,12 @@ namespace brex
     }
 
 
-    std::vector<uint8_t> escapeSingleASCIIRegexChar(RegexChar c)
+    std::vector<uint8_t> escapeSingleCRegexChar(RegexChar c)
     {
         std::vector<uint8_t> acc = {};
 
         if(c == U'%' || c == U'\'' || c == '[' || c == ']' || c == U'/' || c == U'\\' || (c <= 127 && !std::isprint(c))) {
-            auto escc = resolveEscapeASCIIFromCode(c);
+            auto escc = resolveEscapeCFromCode(c);
             while(*escc != '\0') {
                 acc.push_back(*escc++);
             }
@@ -681,14 +653,14 @@ namespace brex
         return acc;
     }
 
-    std::vector<uint8_t> escapeRegexASCIILiteralCharBuffer(const std::vector<RegexChar>& sv)
+    std::vector<uint8_t> escapeRegexCLiteralCharBuffer(const std::vector<RegexChar>& sv)
     {
         std::vector<uint8_t> acc = {};
         for(auto ii = sv.cbegin(); ii != sv.cend(); ++ii) {
             RegexChar c = *ii;
 
             if(c == U'%' || c == U'\'' || c == U'/' || c == U'\\' || (c <= 127 && !std::isprint(c))) {
-                auto escc = resolveEscapeASCIIFromCode(c);
+                auto escc = resolveEscapeCFromCode(c);
                 while(*escc != '\0') {
                     acc.push_back(*escc++);
                 }
@@ -710,9 +682,9 @@ namespace brex
         return std::u8string(ii->second, ii->second + strlen(ii->second));
     }
 
-    std::u8string parserGenerateDiagnosticASCIIEscapeName(uint8_t c)
+    std::u8string parserGenerateDiagnosticCEscapeName(uint8_t c)
     {
-        auto ii = std::find_if(s_escape_names_ascii.cbegin(), s_escape_names_ascii.cend(), [c](const std::pair<uint8_t, const char*>& p) { 
+        auto ii = std::find_if(s_escape_names_char.cbegin(), s_escape_names_char.cend(), [c](const std::pair<uint8_t, const char*>& p) { 
             return p.first == c; 
         });
         return std::u8string(ii->second, ii->second + strlen(ii->second));
@@ -727,7 +699,7 @@ namespace brex
     }
 
     //If we have decode failures then go through and generate nice messages for them
-    std::vector<std::u8string> parserValidateEscapeSequences(bool isascii, bool strict, const uint8_t* s, const uint8_t* e)
+    std::vector<std::u8string> parserValidateEscapeSequences(bool ischar, const uint8_t* s, const uint8_t* e)
     {
         std::vector<std::u8string> errors;
         for(auto curr = s; curr != e; curr++) {
@@ -745,13 +717,13 @@ namespace brex
                         errors.push_back(std::u8string(u8"Hex escape sequence contains non-hex characters"));
                     }
 
-                    auto esc = isascii ? decodeHexEscapeAsASCII(curr, sc + 1, strict).has_value() : decodeHexEscapeAsUnicode(curr, sc + 1).has_value();
+                    auto esc = ischar ? decodeHexEscapeAsC(curr, sc + 1).has_value() : decodeHexEscapeAsUnicode(curr, sc + 1).has_value();
                     if(!esc) {
                         errors.push_back(std::u8string(u8"Invalid hex escape sequence"));
                     }
                 }
                 else {
-                    auto esc = isascii ? resolveEscapeASCIIFromName(curr, sc + 1, strict).has_value() : resolveEscapeUnicodeFromName(curr, sc + 1).has_value();
+                    auto esc = ischar ? resolveEscapeCFromName(curr, sc + 1).has_value() : resolveEscapeUnicodeFromName(curr, sc + 1).has_value();
                     if(!esc) {
                         errors.push_back(std::u8string(u8"Invalid escape sequence -- unknown escape name '" + std::u8string(curr + 1, sc) + u8"'"));
                     }
@@ -808,11 +780,11 @@ namespace brex
         return std::nullopt;
     }
 
-    std::optional<std::u8string> parserValidateAllASCIIEncoding(const uint8_t* s, const uint8_t* e)
+    std::optional<std::u8string> parserValidateAllCEncoding(const uint8_t* s, const uint8_t* e)
     {
         while(s != e) {
             if((*s & 0x80) != 0) {
-                return std::make_optional(std::u8string(u8"Invalid ASCII encoding -- string contains a non-ASCII character"));
+                return std::make_optional(std::u8string(u8"Invalid Char encoding -- string contains a non-char character"));
             }
             else {
                 s++;
@@ -837,7 +809,7 @@ namespace brex
                         return std::make_optional(std::u8string(u8"Hex escape sequence contains non-hex characters -- ") + std::u8string(s + 1, sc));
                     }
 
-                    auto esc = decodeHexEscapeAsRegex(s, sc + 1, false, false);
+                    auto esc = decodeHexEscapeAsRegex(s, sc + 1, false);
                     if(esc.has_value() && esc.value() > 0x10FFFF) {
                         return std::make_optional(std::u8string(u8"Hex escape sequence is not a valid Unicode character -- ") + std::u8string(s + 1, sc));
                     }
@@ -874,10 +846,10 @@ namespace brex
         return std::nullopt;
     }
 
-    std::optional<std::u8string> parserValidateAllASCIIEncoding_SingleChar(const uint8_t* s, const uint8_t* epos, bool strict)
+    std::optional<std::u8string> parserValidateAllCEncoding_SingleChar(const uint8_t* s, const uint8_t* epos)
     {
         if((*s & 0x80) != 0) {
-            return std::make_optional(std::u8string(u8"Invalid ASCII encoding -- string contains a non-ASCII character"));
+            return std::make_optional(std::u8string(u8"Invalid char encoding -- string contains a non-char character"));
         }
         else {
             if(*s == '%') {
@@ -892,9 +864,9 @@ namespace brex
                         return std::make_optional(std::u8string(u8"Hex escape sequence contains non-hex characters -- ") + std::u8string(s + 1, sc));
                     }
 
-                    auto esc = decodeHexEscapeAsRegex(s, sc + 1, true, strict);
+                    auto esc = decodeHexEscapeAsRegex(s, sc + 1, true);
                     if(!esc.has_value() || esc.value() > 127) {
-                        return std::make_optional(std::u8string(u8"Hex escape sequence is not a valid ASCII character -- ") + std::u8string(s + 1, sc));
+                        return std::make_optional(std::u8string(u8"Hex escape sequence is not a valid char character -- ") + std::u8string(s + 1, sc));
                     }
                 }
             }

--- a/src/common.h
+++ b/src/common.h
@@ -161,11 +161,13 @@ namespace brex
     std::vector<uint8_t> extractRegexCharToBytes(RegexChar rc); //utf8 encoded but no escaping
 
     //Take a bytebuffer (of utf8 bytes) with escapes and convert to/from a UnicodeString
-    std::optional<UnicodeString> unescapeUnicodeString(const uint8_t* bytes, size_t length);
+    std::pair<std::optional<UnicodeString>, std::optional<std::u8string>> unescapeUnicodeString(const uint8_t* bytes, size_t length);
+    std::pair<std::optional<UnicodeString>, std::optional<std::u8string>> unescapeUnicodeStringLiteralInclMultiline(const uint8_t* bytes, size_t length);
     std::vector<uint8_t> escapeUnicodeString(const UnicodeString& sv);
 
     //Take a bytebuffer (of char bytes) with escapes and convert to/from an CString
-    std::optional<CString> unescapeCString(const uint8_t* bytes, size_t length);
+    std::pair<std::optional<CString>, std::optional<std::u8string>> unescapeCString(const uint8_t* bytes, size_t length);
+    std::pair<std::optional<CString>, std::optional<std::u8string>> unescapeCStringLiteralInclMultiline(const uint8_t* bytes, size_t length);
     std::vector<uint8_t> escapeCString(const CString& sv);
 
     //Take a bytebuffer regex literal (of utf8 bytes or chat bytes) with escapes and convert to/from a vector of RegexChars

--- a/src/common.h
+++ b/src/common.h
@@ -28,8 +28,8 @@ namespace brex
     typedef std::u8string UnicodeString;
     typedef char8_t UnicodeStringChar;
 
-    typedef std::string ASCIIString;
-    typedef char ASCIIStringChar;
+    typedef std::string CString;
+    typedef char CStringChar;
 
     typedef uint32_t RegexChar;
 
@@ -109,26 +109,26 @@ namespace brex
         }
     };
 
-    class ASCIIRegexIterator
+    class CRegexIterator
     {
     public:
-        const ASCIIString* sstr;
+        const CString* sstr;
         
         int64_t spos; //the first position where the iterator is valid (inclusive)
         int64_t epos; //the last position where the iterator is valid (exclusive)
 
         int64_t curr;
 
-        ASCIIRegexIterator() : sstr(nullptr), spos(0), epos(-1), curr(0) {;}
-        ASCIIRegexIterator(const ASCIIString* sstr) : sstr(sstr), spos(0), epos(sstr->size() - 1), curr(0) {;}
-        ASCIIRegexIterator(const ASCIIString* sstr, int64_t spos, int64_t epos, int64_t curr) : sstr(sstr), spos(spos), epos(epos), curr(curr) {;}
-        ~ASCIIRegexIterator() = default;
+        CRegexIterator() : sstr(nullptr), spos(0), epos(-1), curr(0) {;}
+        CRegexIterator(const CString* sstr) : sstr(sstr), spos(0), epos(sstr->size() - 1), curr(0) {;}
+        CRegexIterator(const CString* sstr, int64_t spos, int64_t epos, int64_t curr) : sstr(sstr), spos(spos), epos(epos), curr(curr) {;}
+        ~CRegexIterator() = default;
 
-        ASCIIRegexIterator(const ASCIIRegexIterator& other) = default;
-        ASCIIRegexIterator(ASCIIRegexIterator&& other) = default;
+        CRegexIterator(const CRegexIterator& other) = default;
+        CRegexIterator(CRegexIterator&& other) = default;
 
-        ASCIIRegexIterator& operator=(const ASCIIRegexIterator& other) = default;
-        ASCIIRegexIterator& operator=(ASCIIRegexIterator&& other) = default;
+        CRegexIterator& operator=(const CRegexIterator& other) = default;
+        CRegexIterator& operator=(CRegexIterator&& other) = default;
         
         inline bool valid() const
         {
@@ -157,44 +157,44 @@ namespace brex
     bool isHexEscapePrefix(const uint8_t* s, const uint8_t* e);
     std::optional<RegexChar> decodeHexEscapeAsRegex(const uint8_t* s, const uint8_t* e);
     std::optional<UnicodeString> decodeHexEscapeAsUnicode(const uint8_t* s, const uint8_t* e);
-    std::optional<ASCIIString> decodeHexEscapeAsASCII(const uint8_t* s, const uint8_t* e, bool strict);
+    std::optional<CString> decodeHexEscapeAsC(const uint8_t* s, const uint8_t* e);
     std::vector<uint8_t> extractRegexCharToBytes(RegexChar rc); //utf8 encoded but no escaping
 
     //Take a bytebuffer (of utf8 bytes) with escapes and convert to/from a UnicodeString
     std::optional<UnicodeString> unescapeUnicodeString(const uint8_t* bytes, size_t length);
     std::vector<uint8_t> escapeUnicodeString(const UnicodeString& sv);
 
-    //Take a bytebuffer (of ascii bytes) with escapes and convert to/from an ASCIIString
-    std::optional<ASCIIString> unescapeASCIIString(const uint8_t* bytes, size_t length, bool strict);
-    std::vector<uint8_t> escapeASCIIString(const ASCIIString& sv);
+    //Take a bytebuffer (of char bytes) with escapes and convert to/from an CString
+    std::optional<CString> unescapeCString(const uint8_t* bytes, size_t length);
+    std::vector<uint8_t> escapeCString(const CString& sv);
 
-    //Take a bytebuffer regex literal (of utf8 bytes or ascii bytes) with escapes and convert to/from a vector of RegexChars
+    //Take a bytebuffer regex literal (of utf8 bytes or chat bytes) with escapes and convert to/from a vector of RegexChars
     std::optional<std::vector<RegexChar>> unescapeUnicodeRegexLiteral(const uint8_t* bytes, size_t length);
-    std::optional<std::vector<RegexChar>> unescapeASCIIRegexLiteral(const uint8_t* bytes, size_t length, bool strict);
+    std::optional<std::vector<RegexChar>> unescapeCRegexLiteral(const uint8_t* bytes, size_t length);
 
-    //Take a bytebuffer regex char range element (of utf8 bytes or ascii bytes) with escapes and convert to a RegexChar
+    //Take a bytebuffer regex char range element (of utf8 bytes or char bytes) with escapes and convert to a RegexChar
     std::optional<RegexChar> unescapeSingleUnicodeRegexChar(const uint8_t* s, const uint8_t* e);
-    std::optional<RegexChar> unescapeSingleASCIIRegexChar(const uint8_t* s, const uint8_t* e, bool strict);
+    std::optional<RegexChar> unescapeSingleCRegexChar(const uint8_t* s, const uint8_t* e);
 
     std::vector<uint8_t> escapeSingleUnicodeRegexChar(RegexChar c);
     std::vector<uint8_t> escapeRegexUnicodeLiteralCharBuffer(const std::vector<RegexChar>& sv);
 
-    std::vector<uint8_t> escapeSingleASCIIRegexChar(RegexChar c);
-    std::vector<uint8_t> escapeRegexASCIILiteralCharBuffer(const std::vector<RegexChar>& sv);
+    std::vector<uint8_t> escapeSingleCRegexChar(RegexChar c);
+    std::vector<uint8_t> escapeRegexCLiteralCharBuffer(const std::vector<RegexChar>& sv);
 
     //In the parser if we find an invalid literal character or code then generate the right way to escape it for a nice error msg
     std::u8string parserGenerateDiagnosticUnicodeEscapeName(uint8_t c);
-    std::u8string parserGenerateDiagnosticASCIIEscapeName(uint8_t c);
+    std::u8string parserGenerateDiagnosticCEscapeName(uint8_t c);
     std::u8string parserGenerateDiagnosticEscapeCode(uint8_t c);
 
     //If we have decode failures then go through and generate nice messages for them
-    std::vector<std::u8string> parserValidateEscapeSequences(bool isascii, bool strict, const uint8_t* s, const uint8_t* e);
+    std::vector<std::u8string> parserValidateEscapeSequences(bool ischar, const uint8_t* s, const uint8_t* e);
 
-    //Scan the string and ensure that there are no multibyte chars that have messed up encodings -- or that the string is only ascii chars
+    //Scan the string and ensure that there are no multibyte chars that have messed up encodings -- or that the string is only char chars
     std::optional<std::u8string> parserValidateUTF8ByteEncoding(const uint8_t* s, const uint8_t* e);
-    std::optional<std::u8string> parserValidateAllASCIIEncoding(const uint8_t* s, const uint8_t* e);
+    std::optional<std::u8string> parserValidateAllCEncoding(const uint8_t* s, const uint8_t* e);
 
     std::optional<std::u8string> parserValidateUTF8ByteEncoding_SingleChar(const uint8_t* s, const uint8_t* epos);
-    std::optional<std::u8string> parserValidateAllASCIIEncoding_SingleChar(const uint8_t* s, const uint8_t* epos, bool strict);
+    std::optional<std::u8string> parserValidateAllCEncoding_SingleChar(const uint8_t* s, const uint8_t* epos);
 }
 

--- a/src/path/path.h
+++ b/src/path/path.h
@@ -7,10 +7,10 @@ namespace bpath
     class AuthorityInfo
     {
     public:
-        const std::optional<brex::ASCIIString> userinfo;
-        const brex::ASCIIString host;
+        const std::optional<brex::CString> userinfo;
+        const brex::CString host;
 
-        AuthorityInfo(std::optional<brex::ASCIIString> userinfo, brex::ASCIIString host) : userinfo(userinfo), host(host) {;}
+        AuthorityInfo(std::optional<brex::CString> userinfo, brex::CString host) : userinfo(userinfo), host(host) {;}
 
         std::u8string toBSQONFormat() const
         {
@@ -27,10 +27,10 @@ namespace bpath
     class ElementInfo
     {
     public:
-        const brex::ASCIIString ename;
-        const std::optional<brex::ASCIIString> ext;
+        const brex::CString ename;
+        const std::optional<brex::CString> ext;
 
-        ElementInfo(brex::ASCIIString ename, std::optional<brex::ASCIIString> ext) : ename(ename), ext(ext) {;}
+        ElementInfo(brex::CString ename, std::optional<brex::CString> ext) : ename(ename), ext(ext) {;}
 
         std::u8string toBSQONFormat() const
         {
@@ -46,14 +46,14 @@ namespace bpath
     class Path
     {
     public:
-        const brex::ASCIIString scheme;
+        const brex::CString scheme;
         const std::optional<AuthorityInfo> authorityinfo;
-        const std::vector<brex::ASCIIString> segments;
+        const std::vector<brex::CString> segments;
         const std::optional<ElementInfo> elementinfo;
 
         const bool tailingslash; //cannot have elementinfo and tailingSlash as false
 
-        Path(brex::ASCIIString scheme, std::optional<AuthorityInfo> authorityinfo, std::vector<brex::ASCIIString> segments, std::optional<ElementInfo> elementinfo, bool tailingslash) : scheme(scheme), authorityinfo(authorityinfo), segments(segments), elementinfo(elementinfo), tailingslash(tailingslash) {;}
+        Path(brex::CString scheme, std::optional<AuthorityInfo> authorityinfo, std::vector<brex::CString> segments, std::optional<ElementInfo> elementinfo, bool tailingslash) : scheme(scheme), authorityinfo(authorityinfo), segments(segments), elementinfo(elementinfo), tailingslash(tailingslash) {;}
         ~Path() {;}
 
         std::u8string toBSQONFormat() const

--- a/src/path/path_fragment.h
+++ b/src/path/path_fragment.h
@@ -8,9 +8,9 @@ namespace bpath
     class PathFragment
     {
     public:
-        const std::optional<brex::ASCIIString> scheme;
+        const std::optional<brex::CString> scheme;
         const std::optional<AuthorityInfo> authorityinfo;
-        const std::optional<std::vector<brex::ASCIIString>> segments;
+        const std::optional<std::vector<brex::CString>> segments;
         const std::optional<ElementInfo> elementinfo;
 
         static PathFragment* jparse(json jv)

--- a/src/path/path_glob.cpp
+++ b/src/path/path_glob.cpp
@@ -28,9 +28,9 @@ namespace bpath
         BREX_ASSERT(jv["value"].is_string(), "Expected string");
 
         std::string value = jv["value"].get<std::string>();
-        auto astr = brex::unescapeASCIIString((uint8_t*)value.c_str(), value.size(), true);
+        auto astr = brex::unescapeCString((uint8_t*)value.c_str(), value.size());
 
-        BREX_ASSERT(astr.has_value(), "Invalid ASCIIString");
+        BREX_ASSERT(astr.has_value(), "Invalid CString");
         return new LiteralComponent(astr.value());
     }
 
@@ -89,9 +89,11 @@ namespace bpath
         BREX_ASSERT(jv["value"].is_string(), "Expected string");
 
         std::string value = jv["value"].get<std::string>();
-        auto astr = brex::unescapeASCIIString((uint8_t*)value.c_str(), value.size(), true);
+        auto astr = brex::unescapeCString((uint8_t*)value.c_str(), value.size());
 
-        BREX_ASSERT(astr.has_value(), "Invalid ASCIIString");
+        BREX_ASSERT(astr.has_value(), "Invalid CString");
+
+        //TODO: need to do more validation here -- like newline is not cool
         return new SegmentLiteralComponent(astr.value());
     }
 

--- a/src/path/path_glob.cpp
+++ b/src/path/path_glob.cpp
@@ -30,8 +30,8 @@ namespace bpath
         std::string value = jv["value"].get<std::string>();
         auto astr = brex::unescapeCString((uint8_t*)value.c_str(), value.size());
 
-        BREX_ASSERT(astr.has_value(), "Invalid CString");
-        return new LiteralComponent(astr.value());
+        BREX_ASSERT(astr.first.has_value(), "Invalid CString");
+        return new LiteralComponent(astr.first.value());
     }
 
     WildcardComponent* WildcardComponent::jparse(json jv)
@@ -91,10 +91,10 @@ namespace bpath
         std::string value = jv["value"].get<std::string>();
         auto astr = brex::unescapeCString((uint8_t*)value.c_str(), value.size());
 
-        BREX_ASSERT(astr.has_value(), "Invalid CString");
+        BREX_ASSERT(astr.first.has_value(), "Invalid CString");
 
         //TODO: need to do more validation here -- like newline is not cool
-        return new SegmentLiteralComponent(astr.value());
+        return new SegmentLiteralComponent(astr.first.value());
     }
 
     SegmentWildcardComponent* SegmentWildcardComponent::jparse(json jv)

--- a/src/path/path_glob.h
+++ b/src/path/path_glob.h
@@ -30,9 +30,9 @@ namespace bpath
     class LiteralComponent : public GlobSimpleComponent
     {
     public:
-        const brex::ASCIIString value;
+        const brex::CString value;
 
-        LiteralComponent(brex::ASCIIString value) : GlobSimpleComponent(GlobSimpleComponentTag::LITERAL_TAG), value(value) {;}
+        LiteralComponent(brex::CString value) : GlobSimpleComponent(GlobSimpleComponentTag::LITERAL_TAG), value(value) {;}
         virtual ~LiteralComponent() {;}
 
         std::u8string toBSQONFormat() const override final
@@ -101,9 +101,9 @@ namespace bpath
     class SegmentLiteralComponent : public SegmentGlobCompnent
     {
     public:
-        const brex::ASCIIString value;
+        const brex::CString value;
 
-        SegmentLiteralComponent(brex::ASCIIString value) : SegmentGlobCompnent(GlobSegmentComponentTag::SEGMENT_LITERAL_TAG), value(value) {;}
+        SegmentLiteralComponent(brex::CString value) : SegmentGlobCompnent(GlobSegmentComponentTag::SEGMENT_LITERAL_TAG), value(value) {;}
         virtual ~SegmentLiteralComponent() {;}
 
         std::u8string toBSQONFormat() const override final

--- a/src/regex/brex.h
+++ b/src/regex/brex.h
@@ -695,50 +695,38 @@ namespace brex
             return u8'<' + this->re->toBSQONFormat() + u8'>';
         }
 
-        bool canUseInTest(bool oobPrefix, bool oobPostfix) const
+        bool canUseInTestOperation() const
         {
-            //Simple -- anchors don't make sense in a test unless we allow OOB prefix or postfix
             if(this->preanchor == nullptr && this->postanchor == nullptr) {
                 return true;
             }
             else {
-                return (oobPrefix || this->preanchor == nullptr) && (oobPostfix || this->postanchor == nullptr);
+                return this->re->isContainsable();
             }
         }
 
-        bool canStartsWith(bool oobPrefix) const
+        bool canStartsOperation() const
         {
-            //either the pre-anchor is null or we are allowing us to match "out of bounds" backward on the string for the prefix
-            return this->re->isMatchable() && (oobPrefix || this->preanchor == nullptr);
+            if(this->preanchor == nullptr) {
+                return this->re->isMatchable();
+            }
+            else {
+                return this->re->isContainsable();
+            }
         }
 
-        bool canEndsWith(bool oobPostfix) const
+        bool canEndOperation() const
         {
-            //either the post-anchor is null or we are allowing us to match "out of bounds" forward on the string for the postfix
-            return this->re->isMatchable() && (oobPostfix || this->postanchor == nullptr);
+            if(this->postanchor == nullptr) {
+                return this->re->isMatchable();
+            }
+            else {
+                return this->re->isContainsable();
+            }
         }
 
         bool canUseInContains() const
         {
-            //re must be containsable (e.g. quickly searchable for a match in a larger string) 
-            return this->re->isContainsable();
-        }
-
-        bool canUseInMatchStart(bool oobPrefix) const
-        {
-            //re must be matchable and either the pre-anchor is null or we are allowing us to match "out of bounds" backward on the string for the prefix
-            return this->re->isMatchable() && (oobPrefix || this->preanchor == nullptr);
-        }
-
-        bool canUseInMatchEnd(bool oobPostfix) const
-        {
-            //re must be matchable and either the post-anchor is null or we are allowing us to match "out of bounds" forward on the string for the postfix
-            return this->re->isMatchable() && (oobPostfix || this->postanchor == nullptr);
-        }
-
-        bool canUseInMatchContains() const
-        {
-            //re must be matchable (which containsable implies)
             return this->re->isContainsable();
         }
     };

--- a/src/regex/brex.h
+++ b/src/regex/brex.h
@@ -50,7 +50,7 @@ namespace brex
                 return u8'"' + std::u8string(bbytes.cbegin(), bbytes.cend()) + u8'"';
             }
             else {
-                auto bbytes = escapeRegexASCIILiteralCharBuffer(this->codes);
+                auto bbytes = escapeRegexCLiteralCharBuffer(this->codes);
                 return u8"'" + std::u8string(bbytes.cbegin(), bbytes.cend()) + u8"'";
             }
         }
@@ -89,13 +89,13 @@ namespace brex
             for(auto ii = this->ranges.cbegin(); ii != this->ranges.cend(); ++ii) {
                 auto cr = *ii;
 
-                auto lowbytes = this->isunicode ? escapeSingleUnicodeRegexChar(cr.low) : escapeSingleASCIIRegexChar(cr.low);
+                auto lowbytes = this->isunicode ? escapeSingleUnicodeRegexChar(cr.low) : escapeSingleCRegexChar(cr.low);
                 rngs.append(lowbytes.cbegin(), lowbytes.cend());
 
                 if(cr.low != cr.high) {
                     rngs.push_back('-');
                     
-                    auto highbytes = this->isunicode ? escapeSingleUnicodeRegexChar(cr.high) : escapeSingleASCIIRegexChar(cr.high);
+                    auto highbytes = this->isunicode ? escapeSingleUnicodeRegexChar(cr.high) : escapeSingleCRegexChar(cr.high);
                     rngs.append(highbytes.cbegin(), highbytes.cend());
                 }
             }
@@ -626,7 +626,7 @@ namespace brex
     enum class RegexCharInfoTag
     {
         Unicode,
-        ASCII
+        Char
     };
 
     class Regex
@@ -645,7 +645,7 @@ namespace brex
         static Regex* jparse(json j)
         {
             auto rtag = (!j.contains("isPath") || j["isPath"].is_null()) ? RegexKindTag::Std : RegexKindTag::Path;
-            auto ctag = (!j.contains("isASCII") || !j["isASCII"].get<bool>()) ? RegexCharInfoTag::ASCII : RegexCharInfoTag::Unicode;
+            auto ctag = (!j.contains("isChar") || !j["isChar"].get<bool>()) ? RegexCharInfoTag::Char : RegexCharInfoTag::Unicode;
 
             auto preanchor = (!j.contains("preanchor") || j["preanchor"].is_null()) ? nullptr : RegexComponent::jparse(j["preanchor"]);
             auto postanchor = (!j.contains("postanchor") || j["postanchor"].is_null()) ? nullptr : RegexComponent::jparse(j["postanchor"]);
@@ -678,8 +678,8 @@ namespace brex
                 fchar = u8"p";
             }
             else {
-                if(this->ctag == RegexCharInfoTag::ASCII) {
-                    fchar = u8"a";
+                if(this->ctag == RegexCharInfoTag::Char) {
+                    fchar = u8"c";
                 }
             }
 
@@ -688,7 +688,7 @@ namespace brex
 
         std::u8string toBSQONGlobFormat() const 
         {
-            BREX_ASSERT(this->ctag == RegexCharInfoTag::ASCII, "only ASCII regexes can be converted to glob format");
+            BREX_ASSERT(this->ctag == RegexCharInfoTag::Char, "only char regexes can be converted to glob format");
             BREX_ASSERT(this->preanchor == nullptr, "only regexes without a preanchor can be converted to glob format");
             BREX_ASSERT(this->postanchor == nullptr, "only regexes without a postanchor can be converted to glob format");
 

--- a/src/regex/brex_cmd.cpp
+++ b/src/regex/brex_cmd.cpp
@@ -198,7 +198,7 @@ int main(int argc, char** argv)
         for(auto citer = envval; *citer != '\0'; ++citer) {
             auto cc = (uint8_t)*citer;
             if(cc <= 127 && !(std::isprint(cc) || std::isblank(cc))) {
-                std::cout << "Environment variable " << *iter << " contains non-ascii or non-printable characters" << std::endl;
+                std::cout << "Environment variable " << *iter << " contains non-char or non-printable characters" << std::endl;
                 return 1;
             }
 

--- a/src/regex/brex_compiler.h
+++ b/src/regex/brex_compiler.h
@@ -202,10 +202,10 @@ namespace brex
             return compileRegexToExecutor<UnicodeString, UnicodeRegexIterator>(re, namedRegexes, envRegexes, envEnabled, resolverState, nameResolverFn, errinfo);
         }
 
-        static ASCIIRegexExecutor* compileASCIIRegexToExecutor(const Regex* re, const std::map<std::string, const RegexOpt*>& namedRegexes, const std::map<std::string, const LiteralOpt*>& envRegexes, bool envEnabled, NameResolverState resolverState, fnNameResolver nameResolverFn, std::vector<RegexCompileError>& errinfo)
+        static CRegexExecutor* compileCRegexToExecutor(const Regex* re, const std::map<std::string, const RegexOpt*>& namedRegexes, const std::map<std::string, const LiteralOpt*>& envRegexes, bool envEnabled, NameResolverState resolverState, fnNameResolver nameResolverFn, std::vector<RegexCompileError>& errinfo)
         {
-            if(re->ctag != RegexCharInfoTag::ASCII) {
-                errinfo.push_back(RegexCompileError(u8"Expected an ASCII regex"));
+            if(re->ctag != RegexCharInfoTag::Char) {
+                errinfo.push_back(RegexCompileError(u8"Expected an char regex"));
                 return nullptr;
             }
 
@@ -214,13 +214,13 @@ namespace brex
                 return nullptr;
             }
 
-            return compileRegexToExecutor<ASCIIString, ASCIIRegexIterator>(re, namedRegexes, envRegexes, envEnabled, resolverState, nameResolverFn, errinfo);
+            return compileRegexToExecutor<CString, CRegexIterator>(re, namedRegexes, envRegexes, envEnabled, resolverState, nameResolverFn, errinfo);
         }
 
-        static ASCIIRegexExecutor* compilePathRegexToExecutor(const Regex* re, const std::map<std::string, const RegexOpt*>& namedRegexes, const std::map<std::string, const LiteralOpt*>& envRegexes, bool envEnabled, NameResolverState resolverState, fnNameResolver nameResolverFn, std::vector<RegexCompileError>& errinfo)
+        static CRegexExecutor* compilePathRegexToExecutor(const Regex* re, const std::map<std::string, const RegexOpt*>& namedRegexes, const std::map<std::string, const LiteralOpt*>& envRegexes, bool envEnabled, NameResolverState resolverState, fnNameResolver nameResolverFn, std::vector<RegexCompileError>& errinfo)
         {
-            if(re->ctag != RegexCharInfoTag::ASCII) {
-                errinfo.push_back(RegexCompileError(u8"Expected an ASCII regex"));
+            if(re->ctag != RegexCharInfoTag::Char) {
+                errinfo.push_back(RegexCompileError(u8"Expected an char regex"));
                 return nullptr;
             }
 
@@ -229,7 +229,7 @@ namespace brex
                 return nullptr;
             }
 
-            return compileRegexToExecutor<ASCIIString, ASCIIRegexIterator>(re, namedRegexes, envRegexes, envEnabled, resolverState, nameResolverFn, errinfo);
+            return compileRegexToExecutor<CString, CRegexIterator>(re, namedRegexes, envRegexes, envEnabled, resolverState, nameResolverFn, errinfo);
         }
     };
 }

--- a/src/regex/brex_dbg_host.cpp
+++ b/src/regex/brex_dbg_host.cpp
@@ -40,17 +40,17 @@ int main(int argc, char** argv)
     std::map<std::string, const brex::LiteralOpt*> emap;
 
     /*
-    auto apr = brex::RegexParser::parseASCIIRegex("/[%a;]/");
+    auto apr = brex::RegexParser::parseCRegex("/[%a;]/");
 
-    auto aexecutor = brex::RegexCompiler::compileASCIIRegexToExecutor(apr.first.value(), nmap, emap, false, nullptr, dbg_fnresolve, compileerror);
+    auto aexecutor = brex::RegexCompiler::compileCRegexToExecutor(apr.first.value(), nmap, emap, false, nullptr, dbg_fnresolve, compileerror);
 
-    auto aastr = brex::ASCIIString("abc");
+    auto aastr = brex::CString("abc");
     auto aaccepts = aexecutor->test(&aastr, dummyerr);
     if(aaccepts) {
-        std::cout << "Accepted ASCII" << std::endl;
+        std::cout << "Accepted Chars" << std::endl;
     }
     else {
-        std::cout << "Rejected ASCII" << std::endl;
+        std::cout << "Rejected Chars" << std::endl;
     }
     */
 

--- a/src/regex/brex_dbg_host.cpp
+++ b/src/regex/brex_dbg_host.cpp
@@ -34,10 +34,12 @@ std::string dbg_fnresolve(const std::string& name, brex::NameResolverState s) {
 
 int main(int argc, char** argv)
 {
+    /*
     brex::ExecutorError dummyerr;
     std::vector<brex::RegexCompileError> compileerror;
     std::map<std::string, const brex::RegexOpt*> nmap;
     std::map<std::string, const brex::LiteralOpt*> emap;
+    */
 
     /*
     auto apr = brex::RegexParser::parseCRegex("/[%a;]/");
@@ -54,6 +56,7 @@ int main(int argc, char** argv)
     }
     */
 
+    /*
     bool ok = true;
     ok &= dbg_tryParseIntoNameMap("FilenameFragment", u8"/[a-zA-Z0-9_]+/", nmap);
     if(!ok) {
@@ -80,7 +83,14 @@ int main(int argc, char** argv)
     else {
         std::cout << "Rejected Unicode" << std::endl;
     }
+    */
 
+
+    auto str = std::u8string(u8"%");
+    auto res = brex::unescapeUnicodeStringLiteralInclMultiline((uint8_t*)str.c_str(), str.size());
+
+    auto xstr = res.second.value();
+    std::cout << std::string(xstr.cbegin(), xstr.cend()) << std::endl;
 
     return 0;
 }

--- a/src/regex/brex_dbg_host.cpp
+++ b/src/regex/brex_dbg_host.cpp
@@ -72,8 +72,8 @@ int main(int argc, char** argv)
 
     auto uexecutor = brex::RegexCompiler::compileUnicodeRegexToExecutor(upr.first.value(), nmap, emap, false, nullptr, dbg_fnresolve, compileerror);
 
-    auto ustr = brex::UnicodeString(u8"mark_a.txt");
-    auto uaccepts = uexecutor->test(&ustr, 5, 5, true, true, dummyerr);
+    auto ustr = brex::UnicodeString(u8"mark_a.tmp");
+    auto uaccepts = uexecutor->test(&ustr, 5, 5, dummyerr);
     if(uaccepts) {
         std::cout << "Accepted Unicode" << std::endl;
     }

--- a/src/regex/brex_executor.h
+++ b/src/regex/brex_executor.h
@@ -576,5 +576,5 @@ namespace brex
     };
 
     typedef REExecutor<UnicodeString, UnicodeRegexIterator> UnicodeRegexExecutor;
-    typedef REExecutor<ASCIIString, ASCIIRegexIterator> ASCIIRegexExecutor;
+    typedef REExecutor<CString, CRegexIterator> CRegexExecutor;
 }

--- a/src/regex/brex_executor.h
+++ b/src/regex/brex_executor.h
@@ -325,26 +325,30 @@ namespace brex
         REExecutor(const Regex* declre, ComponentCheckREInfo<TStr, TIter>* optPre, ComponentCheckREInfo<TStr, TIter>* optPost, ComponentCheckREInfo<TStr, TIter>* re) : declre(declre), optPre(optPre), optPost(optPost), re(re) {;}
         ~REExecutor() = default;
 
-        bool test(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        bool test(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canUseInTest(oobPrefix, oobPostfix)) {
+            if(!this->declre->canUseInTestOperation()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return false;
             }
 
-            bool rechk = this->re->test(sstr, spos, epos);
-            if(!rechk) {
-                return false;
+            if(this->optPre == nullptr && this->optPost == nullptr) {
+                return this->re->test(sstr, spos, epos);
             }
+            else {
+                auto opts = this->re->matchContains(sstr, spos, epos);
 
-            bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, 0, spos - 1);
-            bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, epos + 1, (int64_t)sstr->size() - 1);
+                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->test(sstr, spos, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->test(sstr, opt.second + 1, epos);
 
-            return prechk && postchk;
+                    return prechk && postchk;
+                });
+            }
         }
         
-        bool testContains(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        bool testContains(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
             if(!this->declre->canUseInContains()) {
@@ -358,19 +362,19 @@ namespace brex
             else {
                 auto opts = this->re->matchContains(sstr, spos, epos);
 
-                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos, oobPrefix, oobPostfix](const std::pair<int64_t, int64_t>& opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, oobPrefix ? 0 : spos, opt.first - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, oobPostfix ? (int64_t)sstr->size() - 1 : epos);
+                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, spos, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, epos);
 
                     return prechk && postchk;
                 });
             }
         }
 
-        bool testFront(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        bool testFront(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canStartsWith(oobPrefix)) {
+            if(!this->declre->canStartsOperation()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return false;
             }
@@ -379,21 +383,21 @@ namespace brex
                 return this->re->testFront(sstr, spos, epos);
             }
             else {
-                auto opts = this->re->matchFront(sstr, spos, epos);
+                auto opts = this->re->matchContains(sstr, spos, epos);
 
-                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos, oobPostfix](int64_t opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, 0, opt - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt + 1, oobPostfix ? (int64_t)sstr->size() - 1 : epos);
+                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->test(sstr, 0, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, epos);
 
                     return prechk && postchk;
                 });
             }
         }
 
-        bool testBack(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        bool testBack(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canEndsWith(oobPostfix)) {
+            if(!this->declre->canEndOperation()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return false;
             }
@@ -402,21 +406,21 @@ namespace brex
                 return this->re->testBack(sstr, spos, epos);
             }
             else {
-                auto opts = this->re->matchBack(sstr, spos, epos);
+                auto opts = this->re->matchContains(sstr, spos, epos);
 
-                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos, oobPrefix](int64_t opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, oobPrefix ? 0 : spos, opt - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt + 1, (int64_t)sstr->size() - 1);
+                return std::any_of(opts.cbegin(), opts.cend(), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, spos, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->test(sstr, opt.second + 1, (int64_t)sstr->size() - 1);
 
                     return prechk && postchk;
                 });
             }
         }
 
-        std::optional<std::pair<int64_t, int64_t>> matchContainsFirst(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        std::optional<std::pair<int64_t, int64_t>> matchContainsFirst(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canUseInMatchContains()) {
+            if(!this->declre->canUseInContains()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return std::nullopt;
             }
@@ -428,9 +432,9 @@ namespace brex
             else {
                 auto opts = this->re->matchContains(sstr, spos, epos);
 
-                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos, oobPrefix, oobPostfix](const std::pair<int64_t, int64_t>& opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, oobPrefix ? 0 : spos, opt.first - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, oobPostfix ? (int64_t)sstr->size() - 1 : epos);
+                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, spos, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, epos);
 
                     return prechk && postchk;
                 });
@@ -457,10 +461,10 @@ namespace brex
             return std::make_optional(minmmr.back());
         }
 
-        std::optional<std::pair<int64_t, int64_t>> matchContainsLast(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        std::optional<std::pair<int64_t, int64_t>> matchContainsLast(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canUseInMatchContains()) {
+            if(!this->declre->canUseInContains()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return std::nullopt;
             }
@@ -472,9 +476,9 @@ namespace brex
             else {
                 auto opts = this->re->matchContains(sstr, spos, epos);
 
-                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos, oobPrefix, oobPostfix](const std::pair<int64_t, int64_t>& opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, oobPrefix ? 0 : spos, opt.first - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, oobPostfix ? (int64_t)sstr->size() - 1 : epos);
+                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, spos, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, epos);
 
                     return prechk && postchk;
                 });
@@ -501,24 +505,27 @@ namespace brex
             return std::make_optional(maxmmr.front());
         }
 
-        std::optional<int64_t> matchFront(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        std::optional<std::pair<int64_t, int64_t>> matchFront(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canUseInMatchStart(oobPrefix)) {
+            if(!this->declre->canStartsOperation()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return std::nullopt;
             }
 
-            std::vector<int64_t> mmr;
+            std::vector<std::pair<int64_t, int64_t>> mmr;
             if(this->optPre == nullptr && this->optPost == nullptr) {
-                mmr = this->re->matchFront(sstr, spos, epos);
+                std::vector<int64_t> mmrs = this->re->matchFront(sstr, spos, epos);
+                std::transform(mmrs.cbegin(), mmrs.cend(), std::back_inserter(mmr), [sstr](int64_t epos) {
+                    return std::make_pair(0, epos);
+                });
             }
             else {
-                auto opts = this->re->matchFront(sstr, spos, epos);
+                auto opts = this->re->matchContains(sstr, spos, epos);
 
-                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos, oobPostfix](int64_t opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, 0, opt - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt + 1, oobPostfix ? (int64_t)sstr->size() - 1 : epos);
+                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->test(sstr, 0, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, epos);
 
                     return prechk && postchk;
                 });
@@ -527,24 +534,27 @@ namespace brex
             return !mmr.empty() ? std::make_optional(mmr.back()) : std::nullopt;
         }
 
-        std::optional<int64_t> matchBack(TStr* sstr, int64_t spos, int64_t epos, bool oobPrefix, bool oobPostfix, ExecutorError& error)
+        std::optional<std::pair<int64_t, int64_t>> matchBack(TStr* sstr, int64_t spos, int64_t epos, ExecutorError& error)
         {
             error = ExecutorError::Ok;
-            if(!this->declre->canUseInMatchEnd(oobPostfix)) {
+            if(!this->declre->canEndOperation()) {
                 error = ExecutorError::InvalidRegexStructure;
                 return std::nullopt;
             }
 
-            std::vector<int64_t> mmr;
+            std::vector<std::pair<int64_t, int64_t>> mmr;
             if(this->optPre == nullptr && this->optPost == nullptr) {
-                mmr = this->re->matchBack(sstr, spos, epos);
+                std::vector<int64_t> mmrs = this->re->matchBack(sstr, spos, epos);
+                std::transform(mmrs.cbegin(), mmrs.cend(), std::back_inserter(mmr), [sstr](int64_t spos) {
+                    return std::make_pair(spos, (int64_t)sstr->size() - 1);
+                });
             }
             else {
-                auto opts = this->re->matchBack(sstr, spos, epos);
+                auto opts = this->re->matchContains(sstr, spos, epos);
 
-                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos, oobPrefix](int64_t opt) {
-                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, oobPrefix ? 0 : spos, opt - 1);
-                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt + 1, (int64_t)sstr->size() - 1);
+                std::copy_if(opts.cbegin(), opts.cend(), std::back_inserter(mmr), [this, sstr, spos, epos](const std::pair<int64_t, int64_t>& opt) {
+                    bool prechk = this->optPre == nullptr || this->optPre->testBack(sstr, spos, opt.first - 1);
+                    bool postchk = this->optPost == nullptr || this->optPost->testFront(sstr, opt.second + 1, (int64_t)sstr->size() - 1);
 
                     return prechk && postchk;
                 });
@@ -553,16 +563,16 @@ namespace brex
             return !mmr.empty() ? std::make_optional(mmr.back()) : std::nullopt;
         }
 
-        bool test(TStr* sstr, ExecutorError& error) { return this->test(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
+        bool test(TStr* sstr, ExecutorError& error) { return this->test(sstr, 0, (int64_t)sstr->size() - 1, error); }
 
-        bool testContains(TStr* sstr, ExecutorError& error) { return this->testContains(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
-        bool testFront(TStr* sstr, ExecutorError& error) { return this->testFront(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
-        bool testBack(TStr* sstr, ExecutorError& error) { return this->testBack(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
+        bool testContains(TStr* sstr, ExecutorError& error) { return this->testContains(sstr, 0, (int64_t)sstr->size() - 1, error); }
+        bool testFront(TStr* sstr, ExecutorError& error) { return this->testFront(sstr, 0, (int64_t)sstr->size() - 1, error); }
+        bool testBack(TStr* sstr, ExecutorError& error) { return this->testBack(sstr, 0, (int64_t)sstr->size() - 1, error); }
 
-        std::optional<std::pair<int64_t, int64_t>> matchContainsFirst(TStr* sstr, ExecutorError& error) { return this->matchContainsFirst(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
-        std::optional<std::pair<int64_t, int64_t>> matchContainsLast(TStr* sstr, ExecutorError& error) { return this->matchContainsLast(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
-        std::optional<int64_t> matchFront(TStr* sstr, ExecutorError& error) { return this->matchFront(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
-        std::optional<int64_t> matchBack(TStr* sstr, ExecutorError& error) { return this->matchBack(sstr, 0, (int64_t)sstr->size() - 1, false, false, error); }
+        std::optional<std::pair<int64_t, int64_t>> matchContainsFirst(TStr* sstr, ExecutorError& error) { return this->matchContainsFirst(sstr, 0, (int64_t)sstr->size() - 1, error); }
+        std::optional<std::pair<int64_t, int64_t>> matchContainsLast(TStr* sstr, ExecutorError& error) { return this->matchContainsLast(sstr, 0, (int64_t)sstr->size() - 1, error); }
+        std::optional<std::pair<int64_t, int64_t>> matchFront(TStr* sstr, ExecutorError& error) { return this->matchFront(sstr, 0, (int64_t)sstr->size() - 1, error); }
+        std::optional<std::pair<int64_t, int64_t>> matchBack(TStr* sstr, ExecutorError& error) { return this->matchBack(sstr, 0, (int64_t)sstr->size() - 1, error); }
     };
 
     typedef REExecutor<UnicodeString, UnicodeRegexIterator> UnicodeRegexExecutor;

--- a/src/regex/brex_parser.h
+++ b/src/regex/brex_parser.h
@@ -33,13 +33,12 @@ namespace brex
         const uint8_t* epos;
 
         const bool isUnicode;
-        const bool isStrictASCII;
         bool envAllowed;
 
         size_t cline;
         std::vector<RegexParserError> errors;
 
-        RegexParser(const uint8_t* data, size_t len, bool isUnicode, bool isStrictASCII, bool envAllowed) : data(data), cpos(const_cast<uint8_t*>(data)), epos(data + len), isUnicode(isUnicode), isStrictASCII(isStrictASCII), envAllowed(envAllowed), cline(0), errors() {;}
+        RegexParser(const uint8_t* data, size_t len, bool isUnicode, bool envAllowed) : data(data), cpos(const_cast<uint8_t*>(data)), epos(data + len), isUnicode(isUnicode), envAllowed(envAllowed), cline(0), errors() {;}
         ~RegexParser() = default;
 
         inline bool isEOS() const
@@ -224,7 +223,7 @@ namespace brex
                 }
             }
             else {
-                auto encerr = parserValidateAllASCIIEncoding_SingleChar(this->cpos, this->epos, this->isStrictASCII);
+                auto encerr = parserValidateAllCEncoding_SingleChar(this->cpos, this->epos);
                 if(encerr.has_value()) {
                     this->errors.push_back(RegexParserError(this->cline, encerr.value()));
                     this->scanToSyncToken(']', false);
@@ -242,14 +241,14 @@ namespace brex
                     ccode = unescapeSingleUnicodeRegexChar(this->cpos, tpos + 1);
                 }
                 else {
-                    ccode = unescapeSingleASCIIRegexChar(this->cpos, tpos + 1, this->isStrictASCII);
+                    ccode = unescapeSingleCRegexChar(this->cpos, tpos + 1);
                 }
 
                 if(ccode.has_value()) {
                     code = ccode.value();
                 }
                 else {
-                    auto errors = parserValidateEscapeSequences(!unicodeok, this->isStrictASCII, this->cpos, tpos + 1);
+                    auto errors = parserValidateEscapeSequences(!unicodeok, this->cpos, tpos + 1);
                     for(auto ii = errors.cbegin(); ii != errors.cend(); ii++) {
                         this->errors.push_back(RegexParserError(this->cline, *ii));
                     }
@@ -307,7 +306,7 @@ namespace brex
                 auto codes = unescapeUnicodeRegexLiteral(this->cpos + 1, length);
 
                 if(!codes.has_value()) {
-                    auto errors = parserValidateEscapeSequences(false, this->isStrictASCII, this->cpos + 1, this->cpos + 1 + length);
+                    auto errors = parserValidateEscapeSequences(false, this->cpos + 1, this->cpos + 1 + length);
                     for(auto ii = errors.cbegin(); ii != errors.cend(); ii++) {
                         this->errors.push_back(RegexParserError(this->cline, *ii));
                     }
@@ -323,14 +322,14 @@ namespace brex
             }
         }
 
-        const LiteralOpt* parseASCIILiteral()
+        const LiteralOpt* parseCLiteral()
         {
             //read to closing ' -- check for raw newlines in the expression
             size_t length = 0;
             auto curr = this->cpos + 1;
             while(curr != this->epos && *curr != '\'') {
                 if(*curr <= 127 && !std::isprint(*curr) && !std::isblank(*curr)) {
-                    auto esccname = parserGenerateDiagnosticASCIIEscapeName(*curr);
+                    auto esccname = parserGenerateDiagnosticCEscapeName(*curr);
                     auto esccode = parserGenerateDiagnosticEscapeCode(*curr);
                     this->errors.push_back(RegexParserError(this->cline, u8"Newlines and non-printable chars are not allowed regex literals -- escape them with " + esccname + u8" or " + esccode));
                     return nullptr;
@@ -352,7 +351,7 @@ namespace brex
                 return new LiteralOpt({ }, false);
             }
 
-            auto bytechecks = parserValidateAllASCIIEncoding(this->cpos + 1, this->cpos + 1 + length);
+            auto bytechecks = parserValidateAllCEncoding(this->cpos + 1, this->cpos + 1 + length);
             if(bytechecks.has_value()) {
                 this->errors.push_back(RegexParserError(this->cline, bytechecks.value()));
                 this->cpos = curr + 1;
@@ -360,10 +359,10 @@ namespace brex
                 return new LiteralOpt({ }, false);
             }
             else {
-                auto codes = unescapeASCIIRegexLiteral(this->cpos + 1, length, this->isStrictASCII);
+                auto codes = unescapeCRegexLiteral(this->cpos + 1, length);
 
                 if(!codes.has_value()) {
-                    auto errors = parserValidateEscapeSequences(true, this->isStrictASCII, this->cpos + 1, this->cpos + 1 + length);
+                    auto errors = parserValidateEscapeSequences(true, this->cpos + 1, this->cpos + 1 + length);
                     for(auto ii = errors.cbegin(); ii != errors.cend(); ii++) {
                         this->errors.push_back(RegexParserError(this->cline, *ii));
                     }
@@ -508,17 +507,17 @@ namespace brex
                     res = this->parseUnicodeLiteral();
                 }
                 else {
-                    this->errors.push_back(RegexParserError(this->cline, u8"Unicode literals are not allowed in ASCII regexes"));
+                    this->errors.push_back(RegexParserError(this->cline, u8"Unicode literals are not allowed in char regexes"));
                     this->scanToSyncToken('"', true);
                     res = new LiteralOpt({}, false);
                 }
             }
             else if(this->isToken('\'')) {
                 if(!this->isUnicode) {
-                    res = this->parseASCIILiteral();
+                    res = this->parseCLiteral();
                 }
                 else {
-                    this->errors.push_back(RegexParserError(this->cline, u8"ASCII literals are not allowed in Unicode regexes"));
+                    this->errors.push_back(RegexParserError(this->cline, u8"Char literals are not allowed in Unicode regexes"));
                     this->scanToSyncToken('\'', true);
                     res = new LiteralOpt({}, true);  
                 }
@@ -774,7 +773,7 @@ namespace brex
         }
 
     public:
-        static std::pair<std::optional<Regex*>, std::vector<RegexParserError>> parseRegex(uint8_t* data, size_t len, bool isUnicode, bool isStrictASCII, bool isPath, bool envAllowed)
+        static std::pair<std::optional<Regex*>, std::vector<RegexParserError>> parseRegex(uint8_t* data, size_t len, bool isUnicode, bool isPath, bool envAllowed)
         {
             if(len < 1) {
                 return std::make_pair(std::nullopt, std::vector<RegexParserError>{RegexParserError(0, u8"Empty string is not a valid regex -- must be of form /.../")});
@@ -787,7 +786,7 @@ namespace brex
                 return std::make_pair(std::nullopt, std::vector<RegexParserError>{RegexParserError(0, u8"Invalid regex -- must end with /")});
             }
 
-            auto parser = RegexParser(data + 1, len - 2, isUnicode, isStrictASCII, envAllowed);
+            auto parser = RegexParser(data + 1, len - 2, isUnicode, envAllowed);
 
             std::vector<RegexComponent*> rv;
             bool preanchor = false;
@@ -883,7 +882,7 @@ namespace brex
                 return std::make_pair(std::nullopt, parser.errors);
             }
 
-            auto chartype = isUnicode ? RegexCharInfoTag::Unicode : RegexCharInfoTag::ASCII;
+            auto chartype = isUnicode ? RegexCharInfoTag::Unicode : RegexCharInfoTag::Char;
             auto kindtag = isPath ? RegexKindTag::Path : RegexKindTag::Std;
 
             return std::make_pair(std::make_optional(new Regex(kindtag, chartype, prere, postre, re)), std::vector<RegexParserError>());
@@ -891,17 +890,17 @@ namespace brex
 
         static std::pair<std::optional<Regex*>, std::vector<RegexParserError>> parseUnicodeRegex(const std::u8string& re, bool envAllowed)
         {
-            return parseRegex((uint8_t*)re.c_str(), re.size(), true, false, false, envAllowed);
+            return parseRegex((uint8_t*)re.c_str(), re.size(), true, false, envAllowed);
         }
 
-        static std::pair<std::optional<Regex*>, std::vector<RegexParserError>> parseASCIIRegex(const std::string& re, bool envAllowed)
+        static std::pair<std::optional<Regex*>, std::vector<RegexParserError>> parseCRegex(const std::string& re, bool envAllowed)
         {
-            return parseRegex((uint8_t*)re.c_str(), re.size(), false, true, false, envAllowed);
+            return parseRegex((uint8_t*)re.c_str(), re.size(), false, false, envAllowed);
         }
 
         static std::pair<std::optional<Regex*>, std::vector<RegexParserError>> parsePathRegex(const std::string& re, bool envAllowed)
         {
-            return parseRegex((uint8_t*)re.c_str(), re.size(), false, true, false, envAllowed);
+            return parseRegex((uint8_t*)re.c_str(), re.size(), false, true, envAllowed);
         }
     };
 }

--- a/test/regex/docs.cpp
+++ b/test/regex/docs.cpp
@@ -63,8 +63,8 @@ std::optional<brex::UnicodeRegexExecutor*> tryParseForNameSubTest(const std::u8s
     return std::make_optional(executor);
 }
 
-std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIIDocsTest(const std::string& str) {
-    auto pr = brex::RegexParser::parseASCIIRegex(str, false);
+std::optional<brex::CRegexExecutor*> tryParseForCDocsTest(const std::string& str) {
+    auto pr = brex::RegexParser::parseCRegex(str, false);
     if(!pr.first.has_value() || !pr.second.empty()) {
         return std::nullopt;
     }
@@ -72,7 +72,7 @@ std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIIDocsTest(const std::str
     std::map<std::string, const brex::RegexOpt*> namemap;
     std::map<std::string, const brex::LiteralOpt*> envmap;
     std::vector<brex::RegexCompileError> compileerror;
-    auto executor = brex::RegexCompiler::compileASCIIRegexToExecutor(pr.first.value(), namemap, envmap, false, nullptr, nullptr, compileerror);
+    auto executor = brex::RegexCompiler::compileCRegexToExecutor(pr.first.value(), namemap, envmap, false, nullptr, nullptr, compileerror);
     if(!compileerror.empty()) {
         return std::nullopt;
     }
@@ -83,7 +83,7 @@ std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIIDocsTest(const std::str
 #define ACCEPTS_TEST_UNICODE_DOCS(RE, STR, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 #define ACCEPTS_TEST_UNICODE_RNG_DOCS(RE, STR, SPOS, EPOS, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, SPOS, EPOS, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 
-#define ACCEPTS_TEST_ASCII_DOCS(RE, STR, ACCEPT) {auto uustr = brex::ASCIIString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
+#define ACCEPTS_TEST_C_DOCS(RE, STR, ACCEPT) {auto uustr = brex::CString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 
 BOOST_AUTO_TEST_SUITE(Docs)
 
@@ -112,14 +112,14 @@ BOOST_AUTO_TEST_CASE(thisisaliteralpepper) {
     ACCEPTS_TEST_UNICODE_DOCS(executor, u8"abcd", false);
     ACCEPTS_TEST_UNICODE_DOCS(executor, u8"unicode ", false);
 }
-BOOST_AUTO_TEST_CASE(thisisaliteralascii) {
-    auto texecutor = tryParseForASCIIDocsTest("/'ascii literals %x59;'/");
+BOOST_AUTO_TEST_CASE(thisisaliteralc) {
+    auto texecutor = tryParseForCDocsTest("/'char literals %x59;'/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII_DOCS(executor, "bob", false);
-    ACCEPTS_TEST_ASCII_DOCS(executor, "ascii literals Y", true);
-    ACCEPTS_TEST_ASCII_DOCS(executor, "ascii literals Z", false);
+    ACCEPTS_TEST_C_DOCS(executor, "bob", false);
+    ACCEPTS_TEST_C_DOCS(executor, "char literals Y", true);
+    ACCEPTS_TEST_C_DOCS(executor, "char literals Z", false);
 }
 BOOST_AUTO_TEST_CASE(twoescapesparse) {
     auto texecutor = tryParseForUnicodeDocsTest(u8"/\"%x7;%x0;\"/");
@@ -203,17 +203,17 @@ BOOST_AUTO_TEST_CASE(aeiou) {
     ACCEPTS_TEST_UNICODE_DOCS(executor, u8"ae ", false);
     ACCEPTS_TEST_UNICODE_DOCS(executor, u8"haec ", false);
 }
-BOOST_AUTO_TEST_CASE(aeiouascii) {
-    auto texecutor = tryParseForASCIIDocsTest("/'h'[aeiou]+/");
+BOOST_AUTO_TEST_CASE(aeiouc) {
+    auto texecutor = tryParseForCDocsTest("/'h'[aeiou]+/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII_DOCS(executor, "", false);
-    ACCEPTS_TEST_ASCII_DOCS(executor, "ha", true);
+    ACCEPTS_TEST_C_DOCS(executor, "", false);
+    ACCEPTS_TEST_C_DOCS(executor, "ha", true);
 
-    ACCEPTS_TEST_ASCII_DOCS(executor, "h", false);
-    ACCEPTS_TEST_ASCII_DOCS(executor, "ae ", false);
-    ACCEPTS_TEST_ASCII_DOCS(executor, "haec ", false);
+    ACCEPTS_TEST_C_DOCS(executor, "h", false);
+    ACCEPTS_TEST_C_DOCS(executor, "ae ", false);
+    ACCEPTS_TEST_C_DOCS(executor, "haec ", false);
 }
 BOOST_AUTO_TEST_CASE(aeiouspaces) {
     auto texecutor = tryParseForUnicodeDocsTest(u8"/\n    \"h\" %%starts with h \n  %* comment *%  [aeiou]+ %%then aeiou\n/");

--- a/test/regex/docs.cpp
+++ b/test/regex/docs.cpp
@@ -81,7 +81,7 @@ std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIIDocsTest(const std::str
 }
 
 #define ACCEPTS_TEST_UNICODE_DOCS(RE, STR, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
-#define ACCEPTS_TEST_UNICODE_RNG_DOCS(RE, STR, SPOS, EPOS, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, SPOS, EPOS, true, true, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
+#define ACCEPTS_TEST_UNICODE_RNG_DOCS(RE, STR, SPOS, EPOS, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, SPOS, EPOS, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 
 #define ACCEPTS_TEST_ASCII_DOCS(RE, STR, ACCEPT) {auto uustr = brex::ASCIIString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 

--- a/test/regex/docs.cpp
+++ b/test/regex/docs.cpp
@@ -81,8 +81,6 @@ std::optional<brex::CRegexExecutor*> tryParseForCDocsTest(const std::string& str
 }
 
 #define ACCEPTS_TEST_UNICODE_DOCS(RE, STR, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
-#define ACCEPTS_TEST_UNICODE_RNG_DOCS(RE, STR, SPOS, EPOS, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, SPOS, EPOS, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
-
 #define ACCEPTS_TEST_C_DOCS(RE, STR, ACCEPT) {auto uustr = brex::CString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 
 BOOST_AUTO_TEST_SUITE(Docs)
@@ -332,16 +330,15 @@ BOOST_AUTO_TEST_CASE(anchorfile) {
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"a.txt", 0, 3, false);
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"a.txt", 0, 0, false);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"a.txt", false);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"a.txt", false);
     
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"mark_a.txt", 5, 5, true);
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"mark_ab.txt", 5, 6, true);
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"mark_a.txt", 5, 6, false);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mark_a.txt", true);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mark_ab.txt", true);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mark_a", true); //! is vacuous
 
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"mak_a.txt", 4, 4, false);
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"mark_a.tmp", 5, 5, false);
-    ACCEPTS_TEST_UNICODE_RNG_DOCS(executor, u8"mark_a.tmpa", 5, 5, false);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mak_a.txt", false);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mark_a.tmp", false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/regex/other_ops.cpp
+++ b/test/regex/other_ops.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(repeat09) {
     auto ustr = brex::UnicodeString(u8"123a456");
     auto rr = executor->matchFront(&ustr, err);
 
-    BOOST_CHECK(rr.has_value() && rr.value() == 2);
+    BOOST_CHECK(rr.has_value() && rr.value() == std::make_pair((int64_t)0, (int64_t)2));
 }
 BOOST_AUTO_TEST_SUITE_END()
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(repeat09) {
     auto ustr = brex::UnicodeString(u8"123a456");
     auto rr = executor->matchBack(&ustr, err);
 
-    BOOST_CHECK(rr.has_value() && rr.value() == 4);
+    BOOST_CHECK(rr.has_value() && rr.value() == std::make_pair((int64_t)4, (int64_t)6));
 }
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/regex/parsing_err.cpp
+++ b/test/regex/parsing_err.cpp
@@ -22,8 +22,8 @@ void checkAndReportErrUnicodeResult(const std::u8string& str, const std::u8strin
     BOOST_ASSERT(str.starts_with(expected));
 }
 
-std::optional<brex::RegexParserError> tryParseForTestError_ASCII(const std::string& str) {
-    auto pr = brex::RegexParser::parseASCIIRegex(str, false);
+std::optional<brex::RegexParserError> tryParseForTestError_C(const std::string& str) {
+    auto pr = brex::RegexParser::parseCRegex(str, false);
     if(pr.second.empty()) {
         return std::nullopt;
     }
@@ -32,7 +32,7 @@ std::optional<brex::RegexParserError> tryParseForTestError_ASCII(const std::stri
     }
 }
 
-void checkAndReportErrASCIIResult(const std::u8string& str, const std::u8string& expected) {
+void checkAndReportErrCResult(const std::u8string& str, const std::u8string& expected) {
     if(!str.starts_with(expected)) {
         std::cout << "Expected: " << std::string(expected.cbegin(), expected.cend()) << std::endl;
         std::cout << "Got: " << std::string(str.cbegin(), str.cend()) << std::endl;
@@ -42,7 +42,7 @@ void checkAndReportErrASCIIResult(const std::u8string& str, const std::u8string&
 }
 
 #define PARSE_TEST_UNICODE(RE, EX) { auto res = tryParseForTestError_Unicode(RE); BOOST_CHECK(res.has_value()); checkAndReportErrUnicodeResult(res.value().msg, EX); }
-#define PARSE_TEST_ASCII(RE, EX) { auto res = tryParseForTestError_ASCII(RE); BOOST_CHECK(res.has_value()); checkAndReportErrASCIIResult(res.value().msg, EX); }
+#define PARSE_TEST_C(RE, EX) { auto res = tryParseForTestError_C(RE); BOOST_CHECK(res.has_value()); checkAndReportErrCResult(res.value().msg, EX); }
 
 BOOST_AUTO_TEST_SUITE(ParsingErr)
 
@@ -67,26 +67,26 @@ BOOST_AUTO_TEST_CASE(escape) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(abc) {
-    PARSE_TEST_ASCII("/'abc/", u8"Unterminated regex literal");
-    PARSE_TEST_ASCII("/abc'/", u8"Invalid regex component -- expected (, [, ', \", {, or . but found \"a\"");
+    PARSE_TEST_C("/'abc/", u8"Unterminated regex literal");
+    PARSE_TEST_C("/abc'/", u8"Invalid regex component -- expected (, [, ', \", {, or . but found \"a\"");
 }
 
 BOOST_AUTO_TEST_CASE(escape) {
-    PARSE_TEST_ASCII("/'%'/", u8"Escape sequence is missing terminal ';'");
-    PARSE_TEST_ASCII("/'%x0'/", u8"Escape sequence is missing terminal ';'");
-    PARSE_TEST_ASCII("/'%59;'/", u8"Invalid escape sequence -- unknown escape name '59'");
-    PARSE_TEST_ASCII("/'%x8f3G;'/", u8"Hex escape sequence contains non-hex characters");
-    PARSE_TEST_ASCII("/'%x100;'/", u8"Invalid hex escape sequence");
-    PARSE_TEST_ASCII("/'%x7F;'/", u8"Invalid hex escape sequence");
-    PARSE_TEST_ASCII("/'%x;'/", u8"Invalid escape sequence -- unknown escape name 'x'");
-    PARSE_TEST_ASCII("/'%bob;'/", u8"Invalid escape sequence -- unknown escape name 'bob'");
+    PARSE_TEST_C("/'%'/", u8"Escape sequence is missing terminal ';'");
+    PARSE_TEST_C("/'%x0'/", u8"Escape sequence is missing terminal ';'");
+    PARSE_TEST_C("/'%59;'/", u8"Invalid escape sequence -- unknown escape name '59'");
+    PARSE_TEST_C("/'%x8f3G;'/", u8"Hex escape sequence contains non-hex characters");
+    PARSE_TEST_C("/'%x100;'/", u8"Invalid hex escape sequence");
+    PARSE_TEST_C("/'%x7F;'/", u8"Invalid hex escape sequence");
+    PARSE_TEST_C("/'%x;'/", u8"Invalid escape sequence -- unknown escape name 'x'");
+    PARSE_TEST_C("/'%bob;'/", u8"Invalid escape sequence -- unknown escape name 'bob'");
 
-    PARSE_TEST_ASCII("/'a🌵c'/", u8"Invalid ASCII encoding -- string contains a non-ASCII character");
-    PARSE_TEST_ASCII("/'%a;'/", u8"Invalid escape sequence -- unknown escape name 'a'");
-    PARSE_TEST_ASCII("/'%x7;'/", u8"Invalid hex escape sequence");
-    PARSE_TEST_ASCII("/'%x127;'/", u8"Invalid hex escape sequence");
+    PARSE_TEST_C("/'a🌵c'/", u8"Invalid Char encoding -- string contains a non-char character");
+    PARSE_TEST_C("/'%a;'/", u8"Invalid escape sequence -- unknown escape name 'a'");
+    PARSE_TEST_C("/'%x7;'/", u8"Invalid hex escape sequence");
+    PARSE_TEST_C("/'%x127;'/", u8"Invalid hex escape sequence");
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
@@ -108,20 +108,20 @@ BOOST_AUTO_TEST_CASE(escape) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(simple) {
-    PARSE_TEST_ASCII("/[06a/", u8"Missing ] in char range regex");
-    PARSE_TEST_ASCII("/[0-9/", u8"Missing ] in char range regex");
-    PARSE_TEST_ASCII("/0]/", u8"Invalid regex component");
+    PARSE_TEST_C("/[06a/", u8"Missing ] in char range regex");
+    PARSE_TEST_C("/[0-9/", u8"Missing ] in char range regex");
+    PARSE_TEST_C("/0]/", u8"Invalid regex component");
 }
 BOOST_AUTO_TEST_CASE(escape) {
-    PARSE_TEST_ASCII("/[%x32;-%tick]/", u8"Escape sequence is missing terminal ';'");
-    PARSE_TEST_ASCII("/[^%x32; %undescore;]/", u8"Invalid escape sequence -- unknown escape name 'undescore'");
-    PARSE_TEST_ASCII("/[^%x32-%undescore;]/", u8"Hex escape sequence contains non-hex characters -- x32-%undescore");
-    PARSE_TEST_ASCII("/[^%32-%undescore;]/", u8"Invalid escape sequence -- unknown escape name '32-%undescore'");
+    PARSE_TEST_C("/[%x32;-%tick]/", u8"Escape sequence is missing terminal ';'");
+    PARSE_TEST_C("/[^%x32; %undescore;]/", u8"Invalid escape sequence -- unknown escape name 'undescore'");
+    PARSE_TEST_C("/[^%x32-%undescore;]/", u8"Hex escape sequence contains non-hex characters -- x32-%undescore");
+    PARSE_TEST_C("/[^%32-%undescore;]/", u8"Invalid escape sequence -- unknown escape name '32-%undescore'");
 
-    PARSE_TEST_ASCII("/[%a;]/", u8"Invalid escape sequence -- unknown escape name 'a'");
-    PARSE_TEST_ASCII("/[^%x127;]/", u8"Hex escape sequence is not a valid ASCII character -- x127");
+    PARSE_TEST_C("/[%a;]/", u8"Invalid escape sequence -- unknown escape name 'a'");
+    PARSE_TEST_C("/[^%x127;]/", u8"Hex escape sequence is not a valid char character -- x127");
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/regex/parsing_ok.cpp
+++ b/test/regex/parsing_ok.cpp
@@ -24,8 +24,8 @@ void checkAndReportOkUnicodeResult(const std::u8string& str, const std::u8string
 
 #define PARSE_TEST_UNICODE(RE, EX) { auto res = tryParseForTestOk_Unicode(RE); BOOST_CHECK(res.has_value()); checkAndReportOkUnicodeResult(res.value(), EX); }
 
-std::optional<std::u8string> tryParseForTestOk_ASCII(const std::string& str) {
-    auto pr = brex::RegexParser::parseASCIIRegex(str, false);
+std::optional<std::u8string> tryParseForTestOk_C(const std::string& str) {
+    auto pr = brex::RegexParser::parseCRegex(str, false);
     if(pr.first.has_value() && pr.second.empty()) {
         return std::make_optional(pr.first.value()->toBSQONFormat());
     }
@@ -34,7 +34,7 @@ std::optional<std::u8string> tryParseForTestOk_ASCII(const std::string& str) {
     }
 }
 
-void checkAndReportOkASCIIResult(const std::u8string& str, const std::u8string& expected) {
+void checkAndReportOkCResult(const std::u8string& str, const std::u8string& expected) {
     if(str != expected) {
         std::cout << "Expected: " << std::string(expected.cbegin(), expected.cend()) << std::endl;
         std::cout << "Got: " << std::string(str.cbegin(), str.cend()) << std::endl;
@@ -43,7 +43,7 @@ void checkAndReportOkASCIIResult(const std::u8string& str, const std::u8string& 
     BOOST_ASSERT(str == expected);
 }
 
-#define PARSE_TEST_ASCII(RE, EX) { auto res = tryParseForTestOk_ASCII(RE); BOOST_CHECK(res.has_value()); checkAndReportOkASCIIResult(res.value(), EX); }
+#define PARSE_TEST_C(RE, EX) { auto res = tryParseForTestOk_C(RE); BOOST_CHECK(res.has_value()); checkAndReportOkCResult(res.value(), EX); }
 
 BOOST_AUTO_TEST_SUITE(ParsingOk)
 
@@ -74,21 +74,21 @@ BOOST_AUTO_TEST_CASE(escape) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(abc) {
-    PARSE_TEST_ASCII("/'abc'/", u8"/'abc'/a");
+    PARSE_TEST_C("/'abc'/", u8"/'abc'/c");
 }
 
 BOOST_AUTO_TEST_CASE(eps) {
-    PARSE_TEST_ASCII("/''/", u8"/''/a");
+    PARSE_TEST_C("/''/", u8"/''/c");
 }
 
 BOOST_AUTO_TEST_CASE(escape) {
-    PARSE_TEST_ASCII("/'%x59;'/", u8"/'Y'/a");
+    PARSE_TEST_C("/'%x59;'/", u8"/'Y'/c");
 
-    PARSE_TEST_ASCII("/'%;'/", u8"/'%;'/a");
-    PARSE_TEST_ASCII("/'%%;'/", u8"/'%%;'/a");
-    PARSE_TEST_ASCII("/'%n;'/", u8"/'%n;'/a");
+    PARSE_TEST_C("/'%;'/", u8"/'%;'/c");
+    PARSE_TEST_C("/'%%;'/", u8"/'%%;'/c");
+    PARSE_TEST_C("/'%n;'/", u8"/'%n;'/c");
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
@@ -117,21 +117,21 @@ BOOST_AUTO_TEST_CASE(escape) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(simple) {
-    PARSE_TEST_ASCII("/[06a]/", u8"/[06a]/a");
-    PARSE_TEST_ASCII("/[0-9]/", u8"/[0-9]/a");
-    PARSE_TEST_ASCII("/[0^]/", u8"/[0^]/a");
+    PARSE_TEST_C("/[06a]/", u8"/[06a]/c");
+    PARSE_TEST_C("/[0-9]/", u8"/[0-9]/c");
+    PARSE_TEST_C("/[0^]/", u8"/[0^]/c");
 }
 BOOST_AUTO_TEST_CASE(combos) {
-    PARSE_TEST_ASCII("/[0-9 +]/", u8"/[0-9 +]/a");
+    PARSE_TEST_C("/[0-9 +]/", u8"/[0-9 +]/c");
 }
 BOOST_AUTO_TEST_CASE(compliment) {
-    PARSE_TEST_ASCII("/[^A-Z]/", u8"/[^A-Z]/a");
+    PARSE_TEST_C("/[^A-Z]/", u8"/[^A-Z]/c");
 }
 BOOST_AUTO_TEST_CASE(escape) {
-    PARSE_TEST_ASCII("/[%x32;-%tick;]/", u8"/[%;-2]/a");
-    PARSE_TEST_ASCII("/[^%x32; %underscore;]/", u8"/[^2 _]/a");
+    PARSE_TEST_C("/[%x32;-%tick;]/", u8"/[%;-2]/c");
+    PARSE_TEST_C("/[^%x32; %underscore;]/", u8"/[^2 _]/c");
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
@@ -150,14 +150,14 @@ BOOST_AUTO_TEST_CASE(combos) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(simple) {
-    PARSE_TEST_ASCII("/./", u8"/./a");
-    PARSE_TEST_ASCII("/[.]/", u8"/[.]/a");
+    PARSE_TEST_C("/./", u8"/./c");
+    PARSE_TEST_C("/[.]/", u8"/[.]/c");
 }
 BOOST_AUTO_TEST_CASE(combos) {
-    PARSE_TEST_ASCII("/.'a'./", u8"/.'a'./a");
-    PARSE_TEST_ASCII("/[0-9]./", u8"/[0-9]./a");
+    PARSE_TEST_C("/.'a'./", u8"/.'a'./c");
+    PARSE_TEST_C("/[0-9]./", u8"/[0-9]./c");
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/regex/test.cpp
+++ b/test/regex/test.cpp
@@ -21,8 +21,8 @@ std::optional<brex::UnicodeRegexExecutor*> tryParseForUnicodeTest(const std::u8s
     return std::make_optional(executor);
 }
 
-std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIITest(const std::string& str) {
-    auto pr = brex::RegexParser::parseASCIIRegex(str, false);
+std::optional<brex::CRegexExecutor*> tryParseForCTest(const std::string& str) {
+    auto pr = brex::RegexParser::parseCRegex(str, false);
     if(!pr.first.has_value() || !pr.second.empty()) {
         return std::nullopt;
     }
@@ -30,7 +30,7 @@ std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIITest(const std::string&
     std::map<std::string, const brex::RegexOpt*> namemap;
     std::map<std::string, const brex::LiteralOpt*> envmap;
     std::vector<brex::RegexCompileError> compileerror;
-    auto executor = brex::RegexCompiler::compileASCIIRegexToExecutor(pr.first.value(), namemap, envmap, false, nullptr, nullptr, compileerror);
+    auto executor = brex::RegexCompiler::compileCRegexToExecutor(pr.first.value(), namemap, envmap, false, nullptr, nullptr, compileerror);
     if(!compileerror.empty()) {
         return std::nullopt;
     }
@@ -40,7 +40,7 @@ std::optional<brex::ASCIIRegexExecutor*> tryParseForASCIITest(const std::string&
 
 #define ACCEPTS_TEST_UNICODE(RE, STR, ACCEPT) {auto uustr = brex::UnicodeString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 
-#define ACCEPTS_TEST_ASCII(RE, STR, ACCEPT) {auto uustr = brex::ASCIIString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
+#define ACCEPTS_TEST_C(RE, STR, ACCEPT) {auto uustr = brex::CString(STR); brex::ExecutorError err; auto accepts = executor->test(&uustr, err); BOOST_CHECK(err == brex::ExecutorError::Ok); BOOST_CHECK(accepts == ACCEPT); }
 
 BOOST_AUTO_TEST_SUITE(Test)
 
@@ -89,37 +89,37 @@ BOOST_AUTO_TEST_CASE(escape) {
     ACCEPTS_TEST_UNICODE(executor, u8"%_aa", false);
 }
 BOOST_AUTO_TEST_SUITE_END()
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(abc) {
-    auto texecutor = tryParseForASCIITest("/'abc'/");
+    auto texecutor = tryParseForCTest("/'abc'/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "abc", true);
-    ACCEPTS_TEST_ASCII(executor, "ab", false);
-    ACCEPTS_TEST_ASCII(executor, "", false);
+    ACCEPTS_TEST_C(executor, "abc", true);
+    ACCEPTS_TEST_C(executor, "ab", false);
+    ACCEPTS_TEST_C(executor, "", false);
 
-    ACCEPTS_TEST_ASCII(executor, "abcd", false);
-    ACCEPTS_TEST_ASCII(executor, "xab", false);
+    ACCEPTS_TEST_C(executor, "abcd", false);
+    ACCEPTS_TEST_C(executor, "xab", false);
 }
 
 BOOST_AUTO_TEST_CASE(eps) {
-    auto texecutor = tryParseForASCIITest("/''/");
+    auto texecutor = tryParseForCTest("/''/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "abc", false);
-    ACCEPTS_TEST_ASCII(executor, "", true);
+    ACCEPTS_TEST_C(executor, "abc", false);
+    ACCEPTS_TEST_C(executor, "", true);
 }
 
 BOOST_AUTO_TEST_CASE(escape) {
-    auto texecutor = tryParseForASCIITest("/'%%;%underscore;%x32;'/");
+    auto texecutor = tryParseForCTest("/'%%;%underscore;%x32;'/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "%_2", true);
-    ACCEPTS_TEST_ASCII(executor, "aaa", false);
-    ACCEPTS_TEST_ASCII(executor, "%_aa", false);
+    ACCEPTS_TEST_C(executor, "%_2", true);
+    ACCEPTS_TEST_C(executor, "aaa", false);
+    ACCEPTS_TEST_C(executor, "%_aa", false);
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
@@ -214,69 +214,69 @@ BOOST_AUTO_TEST_CASE(complimentemoji) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(opts3) {
-    auto texecutor = tryParseForASCIITest("/[06a]/");
+    auto texecutor = tryParseForCTest("/[06a]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "0", true);
-    ACCEPTS_TEST_ASCII(executor, "a", true);
-    ACCEPTS_TEST_ASCII(executor, "6", true);
-    ACCEPTS_TEST_ASCII(executor, "1", false);
-    ACCEPTS_TEST_ASCII(executor, "", false);
+    ACCEPTS_TEST_C(executor, "0", true);
+    ACCEPTS_TEST_C(executor, "a", true);
+    ACCEPTS_TEST_C(executor, "6", true);
+    ACCEPTS_TEST_C(executor, "1", false);
+    ACCEPTS_TEST_C(executor, "", false);
 }
 BOOST_AUTO_TEST_CASE(optsrng) {
-    auto texecutor = tryParseForASCIITest("/[0-9]/");
+    auto texecutor = tryParseForCTest("/[0-9]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "0", true);
-    ACCEPTS_TEST_ASCII(executor, "3", true);
-    ACCEPTS_TEST_ASCII(executor, "9", true);
-    ACCEPTS_TEST_ASCII(executor, "a", false);
-    ACCEPTS_TEST_ASCII(executor, "", false);
+    ACCEPTS_TEST_C(executor, "0", true);
+    ACCEPTS_TEST_C(executor, "3", true);
+    ACCEPTS_TEST_C(executor, "9", true);
+    ACCEPTS_TEST_C(executor, "a", false);
+    ACCEPTS_TEST_C(executor, "", false);
 }
 BOOST_AUTO_TEST_CASE(optshat) {
-    auto texecutor = tryParseForASCIITest("/[0^]/");
+    auto texecutor = tryParseForCTest("/[0^]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "0", true);
-    ACCEPTS_TEST_ASCII(executor, "^", true);
-    ACCEPTS_TEST_ASCII(executor, "1", false);
-    ACCEPTS_TEST_ASCII(executor, "", false);
+    ACCEPTS_TEST_C(executor, "0", true);
+    ACCEPTS_TEST_C(executor, "^", true);
+    ACCEPTS_TEST_C(executor, "1", false);
+    ACCEPTS_TEST_C(executor, "", false);
 }
 BOOST_AUTO_TEST_CASE(combos) {
-    auto texecutor = tryParseForASCIITest("/[0-9 +]/");
+    auto texecutor = tryParseForCTest("/[0-9 +]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "0", true);
-    ACCEPTS_TEST_ASCII(executor, "5", true);
-    ACCEPTS_TEST_ASCII(executor, " ", true);
-    ACCEPTS_TEST_ASCII(executor, "+", true);
-    ACCEPTS_TEST_ASCII(executor, "a", false);
+    ACCEPTS_TEST_C(executor, "0", true);
+    ACCEPTS_TEST_C(executor, "5", true);
+    ACCEPTS_TEST_C(executor, " ", true);
+    ACCEPTS_TEST_C(executor, "+", true);
+    ACCEPTS_TEST_C(executor, "a", false);
 }
 BOOST_AUTO_TEST_CASE(compliment) {
-    auto texecutor = tryParseForASCIITest("/[^A-Z]/");
+    auto texecutor = tryParseForCTest("/[^A-Z]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "0", true);
-    ACCEPTS_TEST_ASCII(executor, "A", false);
-    ACCEPTS_TEST_ASCII(executor, "Q", false);
+    ACCEPTS_TEST_C(executor, "0", true);
+    ACCEPTS_TEST_C(executor, "A", false);
+    ACCEPTS_TEST_C(executor, "Q", false);
 }
 BOOST_AUTO_TEST_CASE(complimet2) {
-    auto texecutor = tryParseForASCIITest("/[^A-Z0a-c]/");
+    auto texecutor = tryParseForCTest("/[^A-Z0a-c]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "5", true);
-    ACCEPTS_TEST_ASCII(executor, " ", true);
-    ACCEPTS_TEST_ASCII(executor, "^", true);
-    ACCEPTS_TEST_ASCII(executor, "0", false);
-    ACCEPTS_TEST_ASCII(executor, "b", false);
+    ACCEPTS_TEST_C(executor, "5", true);
+    ACCEPTS_TEST_C(executor, " ", true);
+    ACCEPTS_TEST_C(executor, "^", true);
+    ACCEPTS_TEST_C(executor, "0", false);
+    ACCEPTS_TEST_C(executor, "b", false);
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
@@ -329,45 +329,45 @@ BOOST_AUTO_TEST_CASE(comborng) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(ASCII)
+BOOST_AUTO_TEST_SUITE(C)
 BOOST_AUTO_TEST_CASE(simple) {
-    auto texecutor = tryParseForASCIITest("/./");
+    auto texecutor = tryParseForCTest("/./");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "a", true);
-    ACCEPTS_TEST_ASCII(executor, ".", true);
-    ACCEPTS_TEST_ASCII(executor, " ", true);
+    ACCEPTS_TEST_C(executor, "a", true);
+    ACCEPTS_TEST_C(executor, ".", true);
+    ACCEPTS_TEST_C(executor, " ", true);
 
-    ACCEPTS_TEST_ASCII(executor, "", false);
+    ACCEPTS_TEST_C(executor, "", false);
 }
 BOOST_AUTO_TEST_CASE(dotrng) {
-    auto texecutor = tryParseForASCIITest("/[.b]/");
+    auto texecutor = tryParseForCTest("/[.b]/");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "a", false);
-    ACCEPTS_TEST_ASCII(executor, ".", true);
-    ACCEPTS_TEST_ASCII(executor, "b", true);
+    ACCEPTS_TEST_C(executor, "a", false);
+    ACCEPTS_TEST_C(executor, ".", true);
+    ACCEPTS_TEST_C(executor, "b", true);
 
-    ACCEPTS_TEST_ASCII(executor, "", false);
+    ACCEPTS_TEST_C(executor, "", false);
 }
 BOOST_AUTO_TEST_CASE(combobe) {
-    auto texecutor = tryParseForASCIITest("/.'b'./");
+    auto texecutor = tryParseForCTest("/.'b'./");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, ".b.", true);
-    ACCEPTS_TEST_ASCII(executor, "bbx", true);
-    ACCEPTS_TEST_ASCII(executor, "ab", false);
+    ACCEPTS_TEST_C(executor, ".b.", true);
+    ACCEPTS_TEST_C(executor, "bbx", true);
+    ACCEPTS_TEST_C(executor, "ab", false);
 }
 BOOST_AUTO_TEST_CASE(comborng) {
-    auto texecutor = tryParseForASCIITest("/[0-9]./");
+    auto texecutor = tryParseForCTest("/[0-9]./");
     BOOST_CHECK(texecutor.has_value());
 
     auto executor = texecutor.value();
-    ACCEPTS_TEST_ASCII(executor, "9b", true);
-    ACCEPTS_TEST_ASCII(executor, "ab", false);
+    ACCEPTS_TEST_C(executor, "9b", true);
+    ACCEPTS_TEST_C(executor, "ab", false);
 }
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/regex/validate_string.cpp
+++ b/test/regex/validate_string.cpp
@@ -1,0 +1,130 @@
+#include <boost/test/unit_test.hpp>
+
+#include "../../src/common.h"
+
+std::pair<std::optional<brex::UnicodeString>, std::optional<std::u8string>> validateString_Unicode(const std::u8string& str) {
+    return brex::unescapeUnicodeString((uint8_t*)str.c_str(), str.size());
+}
+
+std::pair<std::optional<brex::UnicodeString>, std::optional<std::u8string>> validateString_Unicode_Multiline(const std::u8string& str) {
+    return brex::unescapeUnicodeStringLiteralInclMultiline((uint8_t*)str.c_str(), str.size());
+}
+
+#define VALIDATE_TEST_UNICODE(RE, EX) { auto res = validateString_Unicode(RE); BOOST_CHECK(res.first.has_value()); BOOST_ASSERT(res.first.value() == EX); }
+#define VALIDATE_TEST_UNICODE_MULTILINE(RE, EX) { auto res = validateString_Unicode_Multiline(RE); BOOST_CHECK(res.first.has_value()); BOOST_ASSERT(res.first.value() == EX); }
+#define VALIDATE_TEST_UNICODE_FAIL(RE, MSG) { auto res = validateString_Unicode(RE); BOOST_CHECK(res.second.has_value()); std::cout << std::string(res.second.value().cbegin(), res.second.value().cend()) << std::endl; BOOST_ASSERT(res.second.value() == MSG); }
+
+std::pair<std::optional<brex::CString>, std::optional<std::u8string>> validateString_CString(const std::string& str) {
+    return brex::unescapeCString((uint8_t*)str.c_str(), str.size());
+}
+
+std::pair<std::optional<brex::CString>, std::optional<std::u8string>> validateString_CString_Multiline(const std::string& str) {
+    return brex::unescapeCStringLiteralInclMultiline((uint8_t*)str.c_str(), str.size());
+}
+
+#define VALIDATE_TEST_CSTRING(RE, EX) { auto res = validateString_CString(RE); BOOST_CHECK(res.first.has_value()); BOOST_ASSERT(res.first.value() == EX); }
+#define VALIDATE_TEST_CSTRING_MULTILINE(RE, EX) { auto res = validateString_CString_Multiline(RE); BOOST_CHECK(res.has_value()); BOOST_ASSERT(res.first.value() == EX); }
+#define VALIDATE_TEST_CSTRING_FAIL(RE, MSG) { auto res = validateString_CString(RE); BOOST_CHECK(res.second.has_value()); std::cout << std::string(res.second.value().cbegin(), res.second.value().cend()) << std::endl; BOOST_ASSERT(res.second.value() == MSG); }
+
+BOOST_AUTO_TEST_SUITE(ValidateString)
+
+////
+//Basic literal strings (ok)
+BOOST_AUTO_TEST_SUITE(Literal)
+BOOST_AUTO_TEST_SUITE(Unicode)
+BOOST_AUTO_TEST_CASE(abc) {
+    VALIDATE_TEST_UNICODE(u8"abc", u8"abc");
+}
+
+BOOST_AUTO_TEST_CASE(eps) {
+    VALIDATE_TEST_UNICODE(u8"", u8"");
+}
+
+BOOST_AUTO_TEST_CASE(literal) {
+    VALIDATE_TEST_UNICODE(u8"a🌵c", u8"a🌵c");
+}
+
+BOOST_AUTO_TEST_CASE(escape) {
+    VALIDATE_TEST_UNICODE(u8"%x0;", std::u8string({'\0'})); //o/w embedded null gets lost
+    VALIDATE_TEST_UNICODE(u8"%x59;", u8"Y");
+    VALIDATE_TEST_UNICODE(u8"%x1f335;", u8"🌵");
+
+    VALIDATE_TEST_UNICODE(u8"%;", u8"\"");
+    VALIDATE_TEST_UNICODE(u8"%%;", u8"%");
+    VALIDATE_TEST_UNICODE(u8"%n;", u8"\n");
+    VALIDATE_TEST_UNICODE(u8"\t", u8"\t");
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_SUITE(C)
+BOOST_AUTO_TEST_CASE(abc) {
+    VALIDATE_TEST_CSTRING("abc", "abc");
+}
+
+BOOST_AUTO_TEST_CASE(eps) {
+    VALIDATE_TEST_CSTRING("", "");
+}
+
+BOOST_AUTO_TEST_CASE(escape) {
+    VALIDATE_TEST_CSTRING("%x59;", "Y");
+
+    VALIDATE_TEST_CSTRING("%;", "'");
+    VALIDATE_TEST_CSTRING("%%;", "%");
+    VALIDATE_TEST_CSTRING("%n;", "\n");
+    VALIDATE_TEST_CSTRING("\t", "\t");
+    VALIDATE_TEST_CSTRING("\n", "\n");
+}
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+////
+//Basic literal strings (err)
+BOOST_AUTO_TEST_SUITE(Literal_ERR)
+BOOST_AUTO_TEST_SUITE(Unicode_ERR)
+BOOST_AUTO_TEST_CASE(escape_ERR) {
+    VALIDATE_TEST_UNICODE_FAIL(u8"%", u8"Unterminated escape sequence -- missing ;");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%x0", u8"Unterminated escape sequence -- missing ;");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%59;", u8"Invalid escape name -- %59;");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%x8f3G;", u8"err4");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%x100000000000;", u8"err5");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%x1f3335;", u8"err6");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%x;", u8"err7");
+    VALIDATE_TEST_UNICODE_FAIL(u8"%bob;", u8"err8");
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(C_ERR)
+BOOST_AUTO_TEST_CASE(chars_ERR) {
+    VALIDATE_TEST_CSTRING_FAIL("\3", u8"Invalid character in string");
+    VALIDATE_TEST_CSTRING_FAIL("\177", u8"err11");
+    VALIDATE_TEST_CSTRING_FAIL("\v", u8"err12");
+}
+
+BOOST_AUTO_TEST_CASE(escape_ERR) {
+    VALIDATE_TEST_CSTRING_FAIL("%", u8"Unterminated escape sequence -- missing ;");
+    VALIDATE_TEST_CSTRING_FAIL("%x0", u8"Unterminated escape sequence -- missing ;");
+    VALIDATE_TEST_CSTRING_FAIL("%59;", u8"Invalid escape name -- %59;");
+    VALIDATE_TEST_CSTRING_FAIL("%x8f3G;", u8"err16");
+    VALIDATE_TEST_CSTRING_FAIL("%x100;", u8"err17");
+    VALIDATE_TEST_CSTRING_FAIL("%x7F;", u8"err18");
+    VALIDATE_TEST_CSTRING_FAIL("%x;", u8"err19");
+    VALIDATE_TEST_CSTRING_FAIL("%bob;", u8"err20");
+
+    VALIDATE_TEST_CSTRING_FAIL("a🌵c", u8"err21");
+    VALIDATE_TEST_CSTRING_FAIL("%a;", u8"err22");
+    VALIDATE_TEST_CSTRING_FAIL("%x7;", u8"err23");
+    VALIDATE_TEST_CSTRING_FAIL("%x127;", u8"err24");
+}
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+////
+//Strings with multiple lines
+
+////
+//Strings with alignment
+
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
- Eliminate OOB for anchors, now must be in range
- Simplify matchable test for errors -- later do warn for possible performance issues (fun project)
- Add support for validating String literals (not just regex literals) and string inputs (needed for Bosque)