### PR TITLE
Added code for building a system of (possibly) dependent regexs

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -41,7 +41,7 @@ PATH_HEADERS=$(PTH_DIR)path.h $(PTH_DIR)path_fragment.h $(PTH_DIR)path_glob.h
 PATH_SOURCES=$(PTH_DIR)path_glob.cpp
 PATH_OBJS=$(OUT_OBJ)path_glob.o
 
-REGEX_TEST_SOURCES=$(REGEX_TEST_SRC_DIR)main.cpp $(REGEX_TEST_SRC_DIR)validate_string.cpp $(REGEX_TEST_SRC_DIR)parsing_ok.cpp $(REGEX_TEST_SRC_DIR)parsing_err.cpp $(REGEX_TEST_SRC_DIR)test.cpp $(REGEX_TEST_SRC_DIR)other_ops.cpp $(REGEX_TEST_SRC_DIR)docs.cpp
+REGEX_TEST_SOURCES=$(REGEX_TEST_SRC_DIR)main.cpp $(REGEX_TEST_SRC_DIR)validate_string.cpp $(REGEX_TEST_SRC_DIR)parsing_ok.cpp $(REGEX_TEST_SRC_DIR)parsing_err.cpp $(REGEX_TEST_SRC_DIR)test.cpp $(REGEX_TEST_SRC_DIR)other_ops.cpp $(REGEX_TEST_SRC_DIR)docs.cpp $(REGEX_TEST_SRC_DIR)system.cpp
 
 MAKEFLAGS += -j4
 

--- a/build/makefile
+++ b/build/makefile
@@ -33,7 +33,7 @@ COMMON_HEADERS=$(SRC_DIR)common.h
 COMMON_SOURCES=$(SRC_DIR)common.cpp
 COMMON_OBJS=$(OUT_OBJ)common.o
 
-REGEX_HEADERS=$(RE_DIR)brex.h $(RE_DIR)brex_parser.h $(RE_DIR)brex_compiler.h $(RE_DIR)brex_executor.h $(RE_DIR)nfa_machine.h $(RE_DIR)nfa_executor.h
+REGEX_HEADERS=$(RE_DIR)brex_system.h $(RE_DIR)brex.h $(RE_DIR)brex_parser.h $(RE_DIR)brex_compiler.h $(RE_DIR)brex_executor.h $(RE_DIR)nfa_machine.h $(RE_DIR)nfa_executor.h
 REGEX_SOURCES=$(RE_DIR)brex.cpp $(RE_DIR)brex_compiler.cpp $(RE_DIR)nfa_machine.cpp
 REGEX_OBJS=$(OUT_OBJ)brex.o $(OUT_OBJ)brex_compiler.o $(OUT_OBJ)nfa_machine.o
 

--- a/src/regex/brex_cmd.cpp
+++ b/src/regex/brex_cmd.cpp
@@ -184,11 +184,14 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    std::map<std::string, const brex::LiteralOpt*> envmap;
+    std::set<std::string> constnames;
     std::set<std::string> envnames;
-    bool envRequired = brex::RegexCompiler::gatherEnvironmentNames(envnames, pr.first.value());
+    bool envRequired = brex::RegexCompiler::gatherNamedRegexKeys(constnames, envnames, pr.first.value());
+
+    std::map<std::string, const brex::LiteralOpt*> envmap;    
     for(auto iter = envnames.begin(); iter != envnames.end(); ++iter) {
-        char* envval = std::getenv(iter->c_str());
+        std::string ename = iter->substr(1, iter->size() - 2); // Remove the ' and ' from the name
+        char* envval = std::getenv(ename.c_str());
         if(envval == nullptr) {
             std::cout << "Environment variable " << *iter << " is required but not set" << std::endl;
             return 1;

--- a/src/regex/brex_compiler.cpp
+++ b/src/regex/brex_compiler.cpp
@@ -67,8 +67,7 @@ namespace brex
         if(opt->tag == RegexOptTag::NamedRegex) {
             return this->resolveNamedRegexOpt(static_cast<const NamedRegexOpt*>(opt));
         }
-        else if(opt->tag == RegexOptTag::EnvRegex)
-        {
+        else if(opt->tag == RegexOptTag::EnvRegex) {
             return this->resolveEnvRegexOpt(static_cast<const EnvRegexOpt*>(opt));
         }
         else if(opt->tag == RegexOptTag::AnyOf) {
@@ -120,16 +119,18 @@ namespace brex
         }
     }
 
-    void RegexResolver::gatherEnvironmentNames(std::set<std::string>& names, const RegexOpt* opt)
+    void RegexResolver::gatherNamedRegexKeys(std::set<std::string>& cnames, std::set<std::string>& enames, const RegexOpt* opt)
     {
-        if(opt->tag == RegexOptTag::EnvRegex)
-        {
-            names.insert(static_cast<const EnvRegexOpt*>(opt)->ename);
+        if(opt->tag == RegexOptTag::NamedRegex) {
+            cnames.insert(static_cast<const NamedRegexOpt*>(opt)->rname);
+        }
+        else if(opt->tag == RegexOptTag::EnvRegex) {
+            enames.insert(static_cast<const EnvRegexOpt*>(opt)->ename);
         }
         else if(opt->tag == RegexOptTag::AnyOf) {
             const AnyOfOpt* anyofopt = static_cast<const AnyOfOpt*>(opt);
             for(auto ii = anyofopt->opts.cbegin(); ii != anyofopt->opts.cend(); ++ii) {
-                RegexResolver::gatherEnvironmentNames(names, *ii);
+                RegexResolver::gatherNamedRegexKeys(cnames, enames, *ii);
             }
         }
         else
@@ -137,25 +138,25 @@ namespace brex
             switch(opt->tag)
             {
             case RegexOptTag::StarRepeat: {
-                RegexResolver::gatherEnvironmentNames(names, static_cast<const StarRepeatOpt*>(opt)->repeat);
+                RegexResolver::gatherNamedRegexKeys(cnames, enames, static_cast<const StarRepeatOpt*>(opt)->repeat);
                 break;
             }
             case RegexOptTag::PlusRepeat: {
-                RegexResolver::gatherEnvironmentNames(names, static_cast<const PlusRepeatOpt*>(opt)->repeat);
+                RegexResolver::gatherNamedRegexKeys(cnames, enames, static_cast<const PlusRepeatOpt*>(opt)->repeat);
                 break;
             }
             case RegexOptTag::RangeRepeat: {
-                RegexResolver::gatherEnvironmentNames(names, static_cast<const RangeRepeatOpt*>(opt)->repeat);
+                RegexResolver::gatherNamedRegexKeys(cnames, enames, static_cast<const RangeRepeatOpt*>(opt)->repeat);
                 break;
             }
             case RegexOptTag::Optional: {
-                RegexResolver::gatherEnvironmentNames(names, static_cast<const OptionalOpt*>(opt)->opt);
+                RegexResolver::gatherNamedRegexKeys(cnames, enames, static_cast<const OptionalOpt*>(opt)->opt);
                 break;
             }
             case RegexOptTag::Sequence: {
                 auto seqopt = static_cast<const SequenceOpt*>(opt);
                 for(auto ii = seqopt->regexs.cbegin(); ii != seqopt->regexs.cend(); ++ii) {
-                    RegexResolver::gatherEnvironmentNames(names, *ii);
+                    RegexResolver::gatherNamedRegexKeys(cnames, enames, *ii);
                 }
                 break;
             }

--- a/src/regex/brex_compiler.h
+++ b/src/regex/brex_compiler.h
@@ -49,7 +49,7 @@ namespace brex
 
         const RegexOpt* resolve(const RegexOpt* opt);
 
-        static void gatherEnvironmentNames(std::set<std::string>& names, const RegexOpt* opt);
+        static void gatherNamedRegexKeys(std::set<std::string>& cnames, std::set<std::string>& enames, const RegexOpt* opt);
     };
 
     class RegexCompiler
@@ -137,16 +137,16 @@ namespace brex
             }
         }
 
-        static void gatherComponentEnvironmentNames(std::set<std::string>& names, const RegexComponent* cc)
+        static void gatherNamedRegexComponentKeys(std::set<std::string>& constnames, std::set<std::string>& envnames, const RegexComponent* cc)
         {
             if(cc->tag == RegexComponentTag::Single) {
                 auto sc = static_cast<const RegexSingleComponent*>(cc);
-                RegexResolver::gatherEnvironmentNames(names, sc->entry.opt);
+                RegexResolver::gatherNamedRegexKeys(constnames, envnames, sc->entry.opt);
             }
             else {
                 auto allc = static_cast<const RegexAllOfComponent*>(cc);
                 for(auto ii = allc->musts.cbegin(); ii != allc->musts.cend(); ++ii) {
-                    RegexResolver::gatherEnvironmentNames(names, ii->opt);
+                    RegexResolver::gatherNamedRegexKeys(constnames, envnames, ii->opt);
                 }
             }
         }
@@ -172,19 +172,19 @@ namespace brex
             return new REExecutor<TStr, TIter>(re, optPre, optPost, cre);
         }
 
-        static bool gatherEnvironmentNames(std::set<std::string>& names, const Regex* re)
+        static bool gatherNamedRegexKeys(std::set<std::string>& constnames, std::set<std::string>& envnames, const Regex* re)
         {
             if(re->preanchor != nullptr) {
-                RegexCompiler::gatherComponentEnvironmentNames(names, re->preanchor);
+                RegexCompiler::gatherNamedRegexComponentKeys(constnames, envnames, re->preanchor);
             }
 
             if(re->postanchor != nullptr) {
-                RegexCompiler::gatherComponentEnvironmentNames(names, re->postanchor);
+                RegexCompiler::gatherNamedRegexComponentKeys(constnames, envnames, re->postanchor);
             }
 
-            RegexCompiler::gatherComponentEnvironmentNames(names, re->re);
+            RegexCompiler::gatherNamedRegexComponentKeys(constnames, envnames, re->re);
 
-            return !names.empty();
+            return !envnames.empty();
         }
 
         static UnicodeRegexExecutor* compileUnicodeRegexToExecutor(const Regex* re, const std::map<std::string, const RegexOpt*>& namedRegexes, const std::map<std::string, const LiteralOpt*>& envRegexes, bool envEnabled, NameResolverState resolverState, fnNameResolver nameResolverFn, std::vector<RegexCompileError>& errinfo)

--- a/src/regex/brex_dbg_host.cpp
+++ b/src/regex/brex_dbg_host.cpp
@@ -1,6 +1,7 @@
 #include "brex.h"
 #include "brex_parser.h"
 #include "brex_compiler.h"
+#include "brex_system.h"
 
 #include <iostream>
 #include <fstream>
@@ -85,12 +86,55 @@ int main(int argc, char** argv)
     }
     */
 
-
+    /*
     auto str = std::u8string(u8"%");
     auto res = brex::unescapeUnicodeStringLiteralInclMultiline((uint8_t*)str.c_str(), str.size());
 
     auto xstr = res.second.value();
     std::cout << std::string(xstr.cbegin(), xstr.cend()) << std::endl;
+    */
+
+    brex::RENSInfo ninfo = {
+        {
+            "Main",
+            {}
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
+            
+            },
+            {
+                "Bar",
+                u8"/\"xyz\"/"
+            
+            },
+            {
+                "Baz",
+                u8"/${Foo} \"-\" ${Bar}/"
+            
+            }
+        }
+    };
+
+    std::vector<brex::RENSInfo> ninfos = { ninfo };
+    std::vector<std::u8string> errors;
+    auto sys = brex::ReSystem::processSystem(ninfos, errors);
+
+    for(size_t i = 0; i < errors.size(); ++i) {
+        std::cout << "Error: " << std::string(errors[i].cbegin(), errors[i].cend()) << std::endl;
+    }
+
+    auto executor = sys.getUnicodeRE("Main::Baz");
+    brex::UnicodeString ustr = u8"abc-xyz";
+    brex::UnicodeString estr = u8"abc-123";
+    brex::ExecutorError err = brex::ExecutorError::Ok;
+
+    auto okr = executor->test(&ustr, err);
+    auto failr = !executor->test(&estr, err);
+
+    std::cout << "Ok: " << okr << " Fail: " << failr << std::endl;
 
     return 0;
 }

--- a/src/regex/brex_dbg_host.cpp
+++ b/src/regex/brex_dbg_host.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
     std::cout << std::string(xstr.cbegin(), xstr.cend()) << std::endl;
     */
 
-    brex::RENSInfo ninfo = {
+    brex::RENSInfo ninfo1 = {
         {
             "Main",
             {}
@@ -113,12 +113,28 @@ int main(int argc, char** argv)
             {
                 "Baz",
                 u8"/${Foo} \"-\" ${Bar}/"
+            }
+        }
+    };
+    brex::RENSInfo ninfo2 = {
+        {
+            "Other",
+            { {"MM", "Main"} }
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
             
+            },
+            {
+                "Baz",
+                u8"/${Foo} \"-\" ${MM::Foo}/"
             }
         }
     };
 
-    std::vector<brex::RENSInfo> ninfos = { ninfo };
+    std::vector<brex::RENSInfo> ninfos = { ninfo1, ninfo2 };
     std::vector<std::u8string> errors;
     auto sys = brex::ReSystem::processSystem(ninfos, errors);
 
@@ -126,7 +142,7 @@ int main(int argc, char** argv)
         std::cout << "Error: " << std::string(errors[i].cbegin(), errors[i].cend()) << std::endl;
     }
 
-    auto executor = sys.getUnicodeRE("Main::Baz");
+    auto executor = sys.getUnicodeRE("Other::Baz");
     brex::UnicodeString ustr = u8"abc-xyz";
     brex::UnicodeString estr = u8"abc-123";
     brex::ExecutorError err = brex::ExecutorError::Ok;

--- a/src/regex/brex_dbg_host.cpp
+++ b/src/regex/brex_dbg_host.cpp
@@ -6,34 +6,39 @@
 #include <iostream>
 #include <fstream>
 
-
-bool dbg_tryParseIntoNameMap(const std::string& name, const std::u8string& str, std::map<std::string, const brex::RegexOpt*>& nmap) {
+bool dbg_tryParseIntoNameMap(const std::string &name, const std::u8string &str, std::map<std::string, const brex::RegexOpt *> &nmap)
+{
     auto pr = brex::RegexParser::parseUnicodeRegex(str, true);
-    if(!pr.first.has_value() || !pr.second.empty()) {
+    if (!pr.first.has_value() || !pr.second.empty())
+    {
         return false;
     }
 
-    if(pr.first.value()->preanchor != nullptr || pr.first.value()->postanchor != nullptr) {
+    if (pr.first.value()->preanchor != nullptr || pr.first.value()->postanchor != nullptr)
+    {
         return false;
     }
 
-    if(pr.first.value()->re->tag != brex::RegexComponentTag::Single) {
+    if (pr.first.value()->re->tag != brex::RegexComponentTag::Single)
+    {
         return false;
     }
 
-    auto sre = static_cast<const brex::RegexSingleComponent*>(pr.first.value()->re);
-    if(sre->entry.isFrontCheck || sre->entry.isBackCheck || sre->entry.isNegated) {
+    auto sre = static_cast<const brex::RegexSingleComponent *>(pr.first.value()->re);
+    if (sre->entry.isFrontCheck || sre->entry.isBackCheck || sre->entry.isNegated)
+    {
         return false;
     }
 
-    return nmap.insert({ name, sre->entry.opt }).second;
+    return nmap.insert({name, sre->entry.opt}).second;
 }
 
-std::string dbg_fnresolve(const std::string& name, brex::NameResolverState s) {
+std::string dbg_fnresolve(const std::string &name, brex::NameResolverState s)
+{
     return name;
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     /*
     brex::ExecutorError dummyerr;
@@ -94,51 +99,24 @@ int main(int argc, char** argv)
     std::cout << std::string(xstr.cbegin(), xstr.cend()) << std::endl;
     */
 
-    brex::RENSInfo ninfo1 = {
-        {
-            "Main",
-            {}
-        },
-        {
-            {
-                "Foo",
-                u8"/\"abc\"/"
-            
-            },
-            {
-                "Bar",
-                u8"/\"xyz\"/"
-            
-            },
-            {
-                "Baz",
-                u8"/${Foo} \"-\" ${Bar}/"
-            }
-        }
-    };
-    brex::RENSInfo ninfo2 = {
-        {
-            "Other",
-            { {"MM", "Main"} }
-        },
-        {
-            {
-                "Foo",
-                u8"/\"abc\"/"
-            
-            },
-            {
-                "Baz",
-                u8"/${Foo} \"-\" ${MM::Foo}/"
-            }
-        }
-    };
+    brex::RENSInfo ninfo = {
+        {"Main",
+         {}},
+        {{"Foo",
+          u8"/${Baz}/"
 
-    std::vector<brex::RENSInfo> ninfos = { ninfo1, ninfo2 };
+         },
+         {"Baz",
+          u8"/${Foo}/"
+
+         }}};
+
+    std::vector<brex::RENSInfo> ninfos = {ninfo};
     std::vector<std::u8string> errors;
     auto sys = brex::ReSystem::processSystem(ninfos, errors);
 
-    for(size_t i = 0; i < errors.size(); ++i) {
+    for (size_t i = 0; i < errors.size(); ++i)
+    {
         std::cout << "Error: " << std::string(errors[i].cbegin(), errors[i].cend()) << std::endl;
     }
 

--- a/src/regex/brex_parser.h
+++ b/src/regex/brex_parser.h
@@ -477,9 +477,9 @@ namespace brex
                 this->errors.push_back(RegexParserError(this->cline, u8"Missing closing ] in env regex"));
             }
 
-            std::basic_regex idre("^[_a-z][_a-zA-Z0-9]*$");
+            std::basic_regex idre("^'[ -&(-~\t]+'$");
             if(!std::regex_match(name.cbegin(), name.cend(), idre)) {
-                this->errors.push_back(RegexParserError(this->cline, u8"Invalid env regex name -- must be a valid identifier"));
+                this->errors.push_back(RegexParserError(this->cline, u8"Invalid env regex name -- must be a valid env key (as a '' string literal)"));
             }
 
             return new EnvRegexOpt(name);

--- a/src/regex/brex_system.h
+++ b/src/regex/brex_system.h
@@ -268,6 +268,7 @@ namespace brex
             }
 
             if(std::find(pending.begin(), pending.end(), entry->fullname) != pending.end()) {
+                errors.push_back(u8"Cycle detected in regex with " + std::u8string(entry->fullname.cbegin(), entry->fullname.cend()));
                 return false;
             }
 

--- a/src/regex/brex_system.h
+++ b/src/regex/brex_system.h
@@ -1,0 +1,261 @@
+#pragma once
+
+#include "../common.h"
+#include "brex.h"
+#include "brex_parser.h"
+#include "brex_compiler.h"
+#include "brex_executor.h"
+
+namespace brex
+{
+    class ReNSRemapper
+    {
+    public:
+        std::map<std::string, std::map<std::string, std::string>> nsmap;
+
+        ReNSRemapper() {;}
+        ~ReNSRemapper() {;}
+
+        void addSingleNSMapping(const std::string& inns, const std::vector<std::pair<std::string, std::string>>& nsmapping)
+        {
+            std::for_each(nsmapping.begin(), nsmapping.end(), [this, &inns](const std::pair<std::string, std::string>& p) {
+                this->nsmap[inns].insert(p);
+            });
+        }
+
+        void addAllNSMappings(const std::vector<std::pair<std::string, std::vector<std::pair<std::string, std::string>>>>& nsmappings)
+        {
+            std::for_each(nsmappings.begin(), nsmappings.end(), [this](const std::pair<std::string, std::vector<std::pair<std::string, std::string>>>& p) {
+                this->addSingleNSMapping(p.first, p.second);
+            });
+        }
+
+        std::optional<std::string> resolveNamespace(const std::string& inns, const std::string& ns) const
+        {
+            auto nsiter = this->nsmap.find(inns);
+            if(nsiter == this->nsmap.end()) {
+                return std::nullopt;
+            }
+
+            auto nameiter = nsiter->second.find(ns);
+            if(nameiter == nsiter->second.end()) {
+                return std::make_optional(ns);
+            }
+
+            return std::make_optional(nameiter->second);
+        }
+    };
+
+    class ReSystemEntry
+    {
+    public:
+        const std::string ns;
+        const std::string name;
+        const std::string fullname;
+
+        Regex* re;
+        std::vector<std::string> deps;
+
+        ReSystemEntry(const std::string& ns, const std::string& name, const std::string& fullname): ns(ns), name(name), fullname(fullname) {;}
+        virtual ~ReSystemEntry() {;}
+
+        virtual std::optional<std::u8string> compileRegex() = 0;
+
+        bool computeDeps(const ReNSRemapper& remapper)
+        {
+            std::set<std::string> constnames;
+            std::set<std::string> envnames;
+            bool envRequired = brex::RegexCompiler::gatherNamedRegexKeys(constnames, envnames, this->re);
+
+            if(envRequired) {
+                return false;
+            }
+
+            bool failed = false;
+            std::for_each(constnames.begin(), constnames.end(), [this, &remapper, &failed](const std::string& cname) {
+                auto biter = cname.find_last_of("::");
+
+                std::string rname("[error]");
+                if(biter == std::string::npos) {
+                    rname = this->ns + "::" + cname;
+                }
+                else {
+                    auto nsname = cname.substr(0, biter);
+                    auto ename = cname.substr(biter + 1);
+
+                    auto resolvedns = remapper.resolveNamespace(this->ns, nsname);
+                    if(!resolvedns.has_value()) {
+                        failed = true;
+                    }
+                    else {
+                        rname = resolvedns.value() + "::" + ename;
+                    }
+                }
+
+                if(std::find(this->deps.begin(), this->deps.end(), rname) == this->deps.end()) {
+                    this->deps.push_back(rname);
+                }   
+            });
+
+            return !failed;
+        }
+    };
+
+    class ReSystemUnicodeEntry : public ReSystemEntry
+    {
+    public:
+        const std::u8string restr;
+        UnicodeRegexExecutor* executor;
+
+        ReSystemUnicodeEntry(const std::string& ns, const std::string& name, const std::string& fullname, const std::u8string& restr): ReSystemEntry(ns, name, fullname), restr(restr) {;}
+        ~ReSystemUnicodeEntry() {;}
+
+        std::optional<std::u8string> compileRegex() override
+        {
+            auto pr = RegexParser::parseUnicodeRegex(this->restr, false);
+            if(!pr.first.has_value() || !pr.second.empty()) {
+                return !pr.second.empty() ? std::make_optional(pr.second[0].msg) : std::make_optional(u8"Invalid Regex");
+            }
+
+            this->re = pr.first.value();
+            return std::nullopt;
+        }
+    };
+
+    class ReSystemCEntry : public ReSystemEntry
+    {
+    public:
+        const std::string restr;
+        CRegexExecutor* executor;
+
+        ReSystemCEntry(const std::string& ns, const std::string& name, const std::string& fullname, const std::string& restr): ReSystemEntry(ns, name, fullname), restr(restr) {;}
+        ~ReSystemCEntry() {;}
+
+        std::optional<std::u8string> compileRegex() override
+        {
+            auto pr = RegexParser::parseCRegex(this->restr, false);
+            if(!pr.first.has_value() || !pr.second.empty()) {
+                return !pr.second.empty() ? std::make_optional(pr.second[0].msg) : std::make_optional(u8"Invalid Regex");
+            }
+
+            this->re = pr.first.value();
+            return std::nullopt;
+        }
+    };
+
+    class ReSystem
+    {
+    public:
+        ReNSRemapper remapper;
+        std::vector<ReSystemEntry*> entries;
+        std::map<std::string, std::vector<ReSystemEntry*>> depmap;
+
+        ReSystem() {;}
+        ~ReSystem() {;}
+
+        void loadUnicodeEntry(const std::string& ns, const std::string& name, const std::string& fullname, const std::u8string& restr)
+        {
+            auto entry = new ReSystemUnicodeEntry(ns, name, fullname, restr);
+            this->entries.push_back(entry);
+        }
+
+        void loadCStringEntry(const std::string& ns, const std::string& name, const std::string& fullname, const std::string& restr)
+        {
+            auto entry = new ReSystemCEntry(ns, name, fullname, restr);
+            this->entries.push_back(entry);
+        }
+
+        void computeDependencies(std::vector<std::u8string>& errors)
+        {
+            std::for_each(this->entries.begin(), this->entries.end(), [this, &errors](ReSystemEntry* entry) {
+                auto err = entry->compileRegex();
+                if(err.has_value()) {
+                    errors.push_back(err.value());
+                }
+                else {
+                    auto depsok = entry->computeDeps(remapper);
+                    
+                    if(!depsok) {
+                        errors.push_back(u8"Failed to compute dependencies for " + std::u8string(entry->fullname.cbegin(), entry->fullname.cend()));
+                    }
+                }
+            });
+
+            std::for_each(this->entries.begin(), this->entries.end(), [this, &errors](ReSystemEntry* entry) {
+                if(this->depmap.find(entry->fullname) == this->depmap.end()) {
+                    this->depmap.insert({ entry->fullname, {} });
+                }
+
+                std::for_each(entry->deps.begin(), entry->deps.end(), [this, entry, &errors](const std::string& dep) {
+                    auto ii = std::find_if(this->entries.begin(), this->entries.end(), [dep](ReSystemEntry* e) {
+                        return e->fullname == dep;
+                    });
+
+                    if(ii != this->entries.end()) {
+                        this->depmap[entry->fullname].push_back(*ii);
+                    }
+                    else {
+                        errors.push_back(u8"Failed to find dependency " + std::u8string(dep.cbegin(), dep.cend()) + u8" for " + std::u8string(entry->fullname.cbegin(), entry->fullname.cend()));
+                    }
+                });
+            });
+        }
+
+        bool generateSingleExecutable(ReSystemEntry* entry, std::vector<std::u8string>& errors, std::vector<std::string>& pending)
+        {
+            if(std::find(pending.begin(), pending.end(), entry->fullname) != pending.end()) {
+                return false;
+            }
+
+            pending.push_back(entry->fullname);
+ 
+            std::map<std::string, const RegexOpt*> namedRegexes;
+            std::vector<ReSystemEntry*>& deps = this->depmap.find(entry->fullname)->second;
+            auto recok = std::reduce(deps.begin(), deps.end(), true, [this, &errors, &pending, &namedRegexes](bool acc, ReSystemEntry* dep) {
+                auto ok = this->generateSingleExecutable(dep, errors, pending);
+                if(!ok) {
+                    return false;
+                }
+                else {
+                    namedRegexes.insert({ dep->name, dep->re->re });
+                    return acc;
+                }
+            });
+
+            pending.pop_back();
+            if(!recok) {
+                return false;
+            }
+
+xxxx;
+            if(entry->re->ctag == RegexCharInfoTag::Unicode) {
+                auto uentry = dynamic_cast<ReSystemUnicodeEntry*>(entry);
+                auto executor = RegexCompiler::compileUnicodeRegexToExecutor(uentry->re, {}, {}, false, nullptr, nullptr, errors);
+                if(executor == nullptr) {
+                    errors.push_back(u8"Failed to compile executor for " + std::u8string(entry->fullname.cbegin(), entry->fullname.cend()));
+                    return;
+                }
+
+                uentry->executor = executor;
+            }
+            else {
+                auto centry = dynamic_cast<ReSystemCEntry*>(entry);
+                auto executor = RegexCompiler::compileCRegexToExecutor(centry->re, {}, {}, false, nullptr, nullptr, errors);
+                if(executor == nullptr) {
+                    errors.push_back(u8"Failed to compile executor for " + std::u8string(entry->fullname.cbegin(), entry->fullname.cend()));
+                    return;
+                }
+
+                centry->executor = executor;
+            }
+
+           
+            return true;
+        }
+
+        void generateExecutables(std::vector<std::u8string>& errors) {
+            xxxx;            
+        }
+    };
+
+}

--- a/test/regex/system.cpp
+++ b/test/regex/system.cpp
@@ -1,0 +1,32 @@
+#include <boost/test/unit_test.hpp>
+
+#include "../../src/regex/brex_system.h"
+
+BOOST_AUTO_TEST_SUITE(System)
+
+BOOST_AUTO_TEST_SUITE(Single)
+BOOST_AUTO_TEST_CASE(abc) {
+    brex::RENSInfo ninfo = {
+        {
+            "Main",
+            {}
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
+            
+            }
+        }
+    };
+
+    std::vector<brex::RENSInfo> ninfos = { ninfo };
+    std::vector<std::u8string> errors;
+    brex::ReSystem::processSystem(ninfos, errors);
+
+    BOOST_ASSERT(errors.empty());
+
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/regex/system.cpp
+++ b/test/regex/system.cpp
@@ -15,7 +15,6 @@ BOOST_AUTO_TEST_CASE(abc) {
             {
                 "Foo",
                 u8"/\"abc\"/"
-            
             }
         }
     };
@@ -50,7 +49,6 @@ BOOST_AUTO_TEST_CASE(abcxyz) {
             {
                 "Baz",
                 u8"/${Foo} \"-\" ${Bar}/"
-            
             }
         }
     };
@@ -70,6 +68,130 @@ BOOST_AUTO_TEST_CASE(abcxyz) {
 
     BOOST_ASSERT(executor->test(&ustr, err));
     BOOST_ASSERT(!executor->test(&estr, err));
+}
+BOOST_AUTO_TEST_CASE(twons) {
+    brex::RENSInfo ninfo1 = {
+        {
+            "Main",
+            {}
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
+            
+            },
+            {
+                "Bar",
+                u8"/\"xyz\"/"
+            
+            },
+            {
+                "Baz",
+                u8"/${Foo} \"-\" ${Bar}/"
+            }
+        }
+    };
+    brex::RENSInfo ninfo2 = {
+        {
+            "Other",
+            { {"MM", "Main"} }
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
+            
+            },
+            {
+                "Baz",
+                u8"/${Foo} \"-\" ${MM::Foo}/"
+            }
+        }
+    };
+
+    std::vector<brex::RENSInfo> ninfos = { ninfo1, ninfo2 };
+    std::vector<std::u8string> errors;
+    auto sys = brex::ReSystem::processSystem(ninfos, errors);
+
+    BOOST_CHECK(errors.empty());
+    BOOST_CHECK(sys.getUnicodeRE("Other::Foo") != nullptr);
+    BOOST_CHECK(sys.getUnicodeRE("Other::Baz") != nullptr);
+
+    auto executor = sys.getUnicodeRE("Main::Baz");
+    brex::UnicodeString ustr = u8"abc-abc";
+    brex::UnicodeString estr = u8"abc-123";
+    brex::ExecutorError err = brex::ExecutorError::Ok;
+
+    BOOST_ASSERT(executor->test(&ustr, err));
+    BOOST_ASSERT(!executor->test(&estr, err));
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(DAG)
+BOOST_AUTO_TEST_CASE(abcabc) {
+    brex::RENSInfo ninfo = {
+        {
+            "Main",
+            {}
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
+            
+            },
+            {
+                "Baz",
+                u8"/${Foo} \"-\" ${Main::Foo}/"
+            }
+        }
+    };
+
+    std::vector<brex::RENSInfo> ninfos = { ninfo };
+    std::vector<std::u8string> errors;
+    auto sys = brex::ReSystem::processSystem(ninfos, errors);
+
+    BOOST_CHECK(errors.empty());
+    BOOST_CHECK(sys.getUnicodeRE("Main::Foo") != nullptr);
+    BOOST_CHECK(sys.getUnicodeRE("Main::Baz") != nullptr);
+
+    auto executor = sys.getUnicodeRE("Main::Baz");
+    brex::UnicodeString ustr = u8"abc-abc";
+    brex::UnicodeString estr = u8"abc-123";
+    brex::ExecutorError err = brex::ExecutorError::Ok;
+
+    BOOST_ASSERT(executor->test(&ustr, err));
+    BOOST_ASSERT(!executor->test(&estr, err));
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(Cycle)
+BOOST_AUTO_TEST_CASE(abcabc) {
+    brex::RENSInfo ninfo = {
+        {
+            "Main",
+            {}
+        },
+        {
+            {
+                "Foo",
+                u8"/${Baz}/"
+            
+            },
+            {
+                "Baz",
+                u8"/${Foo}/"
+            
+            }
+        }
+    };
+
+    std::vector<brex::RENSInfo> ninfos = { ninfo };
+    std::vector<std::u8string> errors;
+    auto sys = brex::ReSystem::processSystem(ninfos, errors);
+
+    BOOST_ASSERT(!errors.empty());
 }
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/regex/system.cpp
+++ b/test/regex/system.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(twons) {
     BOOST_CHECK(sys.getUnicodeRE("Other::Foo") != nullptr);
     BOOST_CHECK(sys.getUnicodeRE("Other::Baz") != nullptr);
 
-    auto executor = sys.getUnicodeRE("Main::Baz");
+    auto executor = sys.getUnicodeRE("Other::Baz");
     brex::UnicodeString ustr = u8"abc-abc";
     brex::UnicodeString estr = u8"abc-123";
     brex::ExecutorError err = brex::ExecutorError::Ok;

--- a/test/regex/system.cpp
+++ b/test/regex/system.cpp
@@ -29,4 +29,48 @@ BOOST_AUTO_TEST_CASE(abc) {
 }
 BOOST_AUTO_TEST_SUITE_END()
 
+BOOST_AUTO_TEST_SUITE(Chain)
+BOOST_AUTO_TEST_CASE(abcxyz) {
+    brex::RENSInfo ninfo = {
+        {
+            "Main",
+            {}
+        },
+        {
+            {
+                "Foo",
+                u8"/\"abc\"/"
+            
+            },
+            {
+                "Bar",
+                u8"/\"xyz\"/"
+            
+            },
+            {
+                "Baz",
+                u8"/${Foo} \"-\" ${Bar}/"
+            
+            }
+        }
+    };
+
+    std::vector<brex::RENSInfo> ninfos = { ninfo };
+    std::vector<std::u8string> errors;
+    auto sys = brex::ReSystem::processSystem(ninfos, errors);
+
+    BOOST_CHECK(errors.empty());
+    BOOST_CHECK(sys.getUnicodeRE("Main::Foo") != nullptr);
+    BOOST_CHECK(sys.getUnicodeRE("Main::Baz") != nullptr);
+
+    auto executor = sys.getUnicodeRE("Main::Baz");
+    brex::UnicodeString ustr = u8"abc-xyz";
+    brex::UnicodeString estr = u8"abc-123";
+    brex::ExecutorError err = brex::ExecutorError::Ok;
+
+    BOOST_ASSERT(executor->test(&ustr, err));
+    BOOST_ASSERT(!executor->test(&estr, err));
+}
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This feature is targeted at using regexs in a programming language where there are multiple named regular expressions that (may) depend on each-other. Make sure we:
1) resolve the names correctly -- even through namespace renaming
2) catch any cyclic dependencies
3) compile them in dependency order without duplication
