### PR TITLE
fixes for scoped parsing

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,7 +1,5 @@
 #include "common.h"
 
-#include <charconv>
-
 #define UTF8_ENCODING_BYTE_COUNT(B) utf8_encoding_sizes[((uint8_t)(B)) >> 4]
 #define UTF8_IS_CONTINUATION_BYTE(B) (((B) & 0xC0) == 0x80)
 
@@ -239,9 +237,8 @@ namespace brex
             return std::nullopt;
         }
 
-        uint32_t cval = 0;
-        auto eev = std::from_chars<uint32_t>((const char*)(s + 2), (const char*)(e - 1), cval, 16);
-        if(eev.ec != std::errc() || eev.ptr != (const char*)(e - 1)) {
+        uint32_t cval = (uint32_t)std::strtoull((const char*)(s + 2), nullptr, 16);
+        if(errno == ERANGE) {
             return std::nullopt;
         }
 
@@ -268,9 +265,8 @@ namespace brex
             return std::nullopt;
         }
 
-        uint32_t cval = 0;
-        auto eev = std::from_chars<uint32_t>((const char*)(s + 2), (const char*)(e - 1), cval, 16);
-        if(eev.ec != std::errc() || eev.ptr != (const char*)(e - 1)) {
+        uint32_t cval = (uint32_t)std::strtoull((const char*)(s + 2), nullptr, 16);
+        if(errno == ERANGE) {
             return std::nullopt;
         }
 
@@ -302,9 +298,8 @@ namespace brex
             return std::nullopt;
         }
 
-        uint32_t cval = 0;
-        auto eev = std::from_chars<uint32_t>((const char*)(s + 2), (const char*)(e - 1), cval, 16);
-        if(eev.ec != std::errc() || eev.ptr != (const char*)(e - 1)) {
+        uint32_t cval = (uint32_t)std::strtoull((const char*)(s + 2), nullptr, 16);
+        if(errno == ERANGE) {
             return std::nullopt;
         }
 

--- a/src/regex/brex_parser.h
+++ b/src/regex/brex_parser.h
@@ -449,7 +449,7 @@ namespace brex
                 this->errors.push_back(RegexParserError(this->cline, u8"Missing closing } in named regex"));
             }
 
-            std::basic_regex scopere("^([A-Z][_a-zA-Z0-9]+::)*[A-Z][_a-zA-Z0-9]+$");
+            std::basic_regex scopere("^([A-Z][_a-zA-Z0-9]+::)*[_a-zA-Z0-9]+$");
             if(!std::regex_match(name.cbegin(), name.cend(), scopere)) {
                 this->errors.push_back(RegexParserError(this->cline, u8"Invalid named regex name -- must be a valid scoped identifier"));
             }

--- a/test/regex/docs.cpp
+++ b/test/regex/docs.cpp
@@ -340,6 +340,17 @@ BOOST_AUTO_TEST_CASE(anchorfile) {
     ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mak_a.txt", false);
     ACCEPTS_TEST_UNICODE_DOCS(executor, u8"mark_a.tmp", false);
 }
+BOOST_AUTO_TEST_CASE(sccopedname) {
+    std::map<std::string, const brex::RegexOpt*> nmap;
+    BOOST_CHECK(tryParseIntoNameMap("Main::re2", u8"/[a-zA-Z0-9_]+/", nmap));
+
+    auto texecutor = tryParseForNameSubTest(u8"/${Main::re2}/", nmap);
+    BOOST_CHECK(texecutor.has_value());
+
+    auto executor = texecutor.value();
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"", false);
+    ACCEPTS_TEST_UNICODE_DOCS(executor, u8"abc", true);
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Fixed issue with `/${Main::re2}/` type scopes being rejected.